### PR TITLE
Update plugin header name

### DIFF
--- a/sas-plugin.php
+++ b/sas-plugin.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Plugin Name: Sparrow Core
+ * Plugin Name: Blackwork Core
  * Author: Sparrow&Snow
  * Author URI: https://www.blackwork.com
  * Version: 1.0.0


### PR DESCRIPTION
## Summary
- update the WordPress plugin header to rename the plugin to Blackwork Core

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd5d8e95fc8325930edde70942edf6