### PR TITLE
Gate Elementor Pro widgets behind availability checks

### DIFF
--- a/sas-el-widgets.php
+++ b/sas-el-widgets.php
@@ -105,17 +105,33 @@ class BW_Elementor_Widgets {
      * @param $widgets_manager Elementor\Widgets_Manager
      */
     public function include_widgets($widgets_manager) {
-        $files = glob(trailingslashit(BW_PLUGIN_PATH) . '/widgets/header/*.php');
-        foreach ($files as $file){
-            if(file_exists($file)){
-                require_once  $file;
-            }
-        }
+        $elementor_pro_active = did_action( 'elementor_pro/init' ) || class_exists( 'ElementorPro\\Modules\\Woocommerce\\Widgets\\Base_Widget' );
 
-        $files = glob(trailingslashit(BW_PLUGIN_PATH) . '/widgets/content/*.php');
-        foreach ($files as $file){
-            if(file_exists($file)){
-                require_once  $file;
+        $pro_only_files = array_filter( array_map( 'realpath', array(
+            BW_PLUGIN_PATH . 'widgets/content/product-meta.php',
+        ) ) );
+
+        $directories = array( 'header', 'content' );
+
+        foreach ( $directories as $directory ) {
+            $files = glob( BW_PLUGIN_PATH . 'widgets/' . $directory . '/*.php' );
+
+            if ( empty( $files ) ) {
+                continue;
+            }
+
+            foreach ( $files as $file ) {
+                if ( ! file_exists( $file ) ) {
+                    continue;
+                }
+
+                $real_file = realpath( $file );
+
+                if ( ! $elementor_pro_active && $real_file && in_array( $real_file, $pro_only_files, true ) ) {
+                    continue;
+                }
+
+                require_once $file;
             }
         }
     }

--- a/widgets/content/product-meta.php
+++ b/widgets/content/product-meta.php
@@ -6,8 +6,10 @@ use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use Elementor\Group_Control_Typography;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+        exit; // Exit if accessed directly
 }
+
+if ( \did_action( 'elementor_pro/init' ) || \class_exists( 'ElementorPro\\Modules\\Woocommerce\\Widgets\\Base_Widget' ) ) {
 
 class BW_Product_Meta extends Base_Widget {
 
@@ -447,5 +449,6 @@ class BW_Product_Meta extends Base_Widget {
 	}
 }
 
+$widgets_manager->register( new BW_Product_Meta() );
 
-$widgets_manager->register(new BW_Product_Meta());
+}


### PR DESCRIPTION
## Summary
- update widget inclusion logic to skip Elementor Pro-specific files when Pro is inactive
- guard the Product Meta widget definition and registration behind the same Elementor Pro availability check

## Testing
- php -l sas-el-widgets.php
- php -l widgets/content/product-meta.php

------
https://chatgpt.com/codex/tasks/task_e_68d5aec63774832585fd4b975bd8dce8