### PR TITLE
Fix isotope script registration for Elementor grids

### DIFF
--- a/sas-el-widgets.php
+++ b/sas-el-widgets.php
@@ -85,16 +85,22 @@ class BW_Elementor_Widgets {
 		
 
     // Content
-		wp_register_script('isotope', trailingslashit(BW_PLUGIN_URL) . 'assets/js/isotope.js', array(),'',true);
-		wp_register_script('sas-productslider', trailingslashit(BW_PLUGIN_URL) . 'widgets/assets/js/products-slider.js', array('jquery'), BW_PLUGIN_VERSION, true);
-	    wp_register_script('sas-woo-products', trailingslashit(BW_PLUGIN_URL) . 'widgets/assets/js/woo-products.js', array('jquery'), BW_PLUGIN_VERSION, true);
+                wp_register_script(
+                        'isotope',
+                        'https://cdnjs.cloudflare.com/ajax/libs/jquery.isotope/3.0.6/isotope.pkgd.min.js',
+                        array( 'jquery' ),
+                        '3.0.6',
+                        true
+                );
+                wp_register_script('sas-productslider', trailingslashit(BW_PLUGIN_URL) . 'widgets/assets/js/products-slider.js', array('jquery'), BW_PLUGIN_VERSION, true);
+            wp_register_script('sas-woo-products', trailingslashit(BW_PLUGIN_URL) . 'widgets/assets/js/woo-products.js', array('jquery', 'imagesloaded'), BW_PLUGIN_VERSION, true);
 
 	    wp_register_script('sas-mobile-menu-js', trailingslashit(BW_PLUGIN_URL) . 'widgets/assets/js/mobile-menu.js', array('jquery'), BW_PLUGIN_VERSION, true);
 
    
     // Grid isotope layout
 	    wp_register_script('sas-products', trailingslashit(BW_PLUGIN_URL) . 'widgets/assets/js/products.js', array('jquery'), BW_PLUGIN_VERSION, true);
-	    wp_register_script('sas-blog-grid', trailingslashit(BW_PLUGIN_URL) . 'widgets/assets/js/blog-grid.js', array('jquery'), BW_PLUGIN_VERSION, true);
+            wp_register_script('sas-blog-grid', trailingslashit(BW_PLUGIN_URL) . 'widgets/assets/js/blog-grid.js', array('jquery', 'imagesloaded'), BW_PLUGIN_VERSION, true);
 	    wp_register_script('sas-fixed-price-bar', trailingslashit(BW_PLUGIN_URL) . 'widgets/assets/js/fixed-price-bar.js', array('jquery'), BW_PLUGIN_VERSION, true);
         
 		wp_localize_script( 'sas-blog-grid', 'ajax_object', array('ajaxurl' => admin_url( 'admin-ajax.php' )));

--- a/widgets/content/blackworkpro-products.php
+++ b/widgets/content/blackworkpro-products.php
@@ -35,7 +35,7 @@ class BW_Blackworkpro_Products extends Widget_Base {
         }
 
         public function get_script_depends() {
-                return [ 'sas-woo-products' ];
+                return [ 'isotope', 'sas-woo-products' ];
         }
 
         protected function register_controls() {

--- a/widgets/content/products.php
+++ b/widgets/content/products.php
@@ -37,9 +37,9 @@ class BW_Woo_Products extends Widget_Base {
 		return [ 'sas-base' ];
 	}
 	//JS
-	public function get_script_depends() {
-		return [ 'sas-woo-products' ];
-	}
+        public function get_script_depends() {
+                return [ 'isotope', 'sas-woo-products' ];
+        }
 	
 	
 	// CONTROLS **********


### PR DESCRIPTION
## Summary
- register the Elementor isotope handle against the public Isotope CDN build and ensure related scripts depend on imagesLoaded
- make both WooCommerce product widgets declare the isotope handle alongside their existing script dependency so the masonry helper loads reliably

## Testing
- not run (WordPress plugin)


------
https://chatgpt.com/codex/tasks/task_e_68d5bb58ce548325862f8655f2beac57