### PR TITLE
Add BW Elementor Widgets plugin skeleton

### DIFF
--- a/bw-elementor-widgets/README.md
+++ b/bw-elementor-widgets/README.md
@@ -1,0 +1,86 @@
+# BW Elementor Widgets
+
+Collezione di **widget personalizzati per Elementor** sviluppati per BW.  
+Questo plugin raccoglie più widget, ognuno organizzato in file separati per garantire modularità e scalabilità.
+
+---
+
+## 📂 Struttura cartelle
+
+```
+bw-elementor-widgets/
+│── bw-main-elementor-widgets.php        // file principale del plugin
+│── includes/
+│    │── class-bw-widget-loader.php      // loader automatico dei widget
+│    │── widgets/
+│    │    │── class-bw-products-slide-widget.php
+│── assets/
+│    ├── css/
+│    │    └── bw-products-slide.css
+│    └── js/
+│         └── bw-products-slide.js
+```
+
+---
+
+## ⚙️ Installazione
+
+1. Clona o scarica la cartella `bw-elementor-widgets` in `wp-content/plugins/`.
+2. Verifica che Elementor sia installato e attivo.
+3. Attiva il plugin **BW Elementor Widgets** da **Plugin > Aggiungi nuovo** su WordPress.
+4. Troverai i nuovi widget nella dashboard Elementor, sotto la categoria **General** (o personalizzata).
+
+---
+
+## 🚀 Widget attuali
+
+### BW Products Slide
+Uno slider basato su **Flickity** che mostra prodotti o post con controlli configurabili da Elementor:
+
+- **Query**  
+  - Post type  
+  - Categoria  
+  - ID specifici  
+
+- **Display Options**  
+  - Mostra/Nascondi titolo  
+  - Mostra/Nascondi sottotitolo (excerpt)  
+  - Mostra/Nascondi prezzo (WooCommerce)  
+
+- **Layout**  
+  - Numero di colonne (2–6)  
+  - Spazio tra colonne  
+
+- **Slider Settings**  
+  - Velocità autoplay (ms)  
+  - Loop infinito  
+  - Effetto fade  
+
+---
+
+## 🛠 Aggiungere un nuovo widget
+
+1. Crea un nuovo file in `includes/widgets/` con il nome:  
+   ```
+   class-bw-nome-widget.php
+   ```
+   La classe deve chiamarsi:
+   ```
+   Widget_Bw_Nome_Widget
+   ```
+
+2. Aggiungi eventuali CSS in `assets/css/bw-nome-widget.css`.  
+3. Aggiungi eventuali JS in `assets/js/bw-nome-widget.js`.  
+4. Il **loader** (`class-bw-widget-loader.php`) registrerà automaticamente il nuovo widget, non serve modificare altro.  
+
+---
+
+## 📦 Dipendenze
+
+- [Elementor](https://elementor.com/)  
+- [Flickity](https://flickity.metafizzy.co/) (incluso via CDN)  
+
+---
+
+## 👨‍💻 Autore
+Simone

--- a/bw-elementor-widgets/assets/css/bw-products-slide.css
+++ b/bw-elementor-widgets/assets/css/bw-products-slide.css
@@ -1,0 +1,20 @@
+.bw-products-slider {
+  width: 100%;
+}
+
+.carousel-cell {
+  width: calc(100% / var(--columns));
+  margin-right: var(--gap);
+}
+
+.carousel-cell img {
+  display: block;
+  max-width: 100%;
+  border: 1px solid #000;
+}
+
+.caption {
+  margin-top: 10px;
+  text-align: center;
+  font-family: serif;
+}

--- a/bw-elementor-widgets/assets/js/bw-products-slide.js
+++ b/bw-elementor-widgets/assets/js/bw-products-slide.js
@@ -1,0 +1,18 @@
+jQuery(document).ready(function($){
+  $('.bw-products-slider').each(function(){
+    let el = $(this);
+
+    let autoplay = el.data('autoplay');
+    let wrap = el.data('wrap') === 'yes';
+    let fade = el.data('fade') === 'yes';
+
+    el.flickity({
+      cellAlign: 'left',
+      contain: true,
+      groupCells: true,
+      autoPlay: autoplay ? autoplay : false,
+      wrapAround: wrap,
+      fade: fade
+    });
+  });
+});

--- a/bw-elementor-widgets/bw-main-elementor-widgets.php
+++ b/bw-elementor-widgets/bw-main-elementor-widgets.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Plugin Name: BW Elementor Widgets
+ * Description: Collezione di widget personalizzati per Elementor
+ * Version: 1.0.0
+ * Author: Simone
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+// Loader dei widget
+require_once __DIR__ . '/includes/class-bw-widget-loader.php';
+
+// Registrazione eventuali asset globali
+function bw_widgets_register_assets() {
+    // Se vuoi aggiungere un CSS/JS condiviso tra tutti i widget
+    // wp_register_style('bw-widgets-global', plugins_url('/assets/css/global.css', __FILE__));
+    // wp_enqueue_style('bw-widgets-global');
+}
+add_action('wp_enqueue_scripts', 'bw_widgets_register_assets');

--- a/bw-elementor-widgets/includes/class-bw-widget-loader.php
+++ b/bw-elementor-widgets/includes/class-bw-widget-loader.php
@@ -1,0 +1,32 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+class BW_Widget_Loader {
+    public function __construct() {
+        add_action('elementor/widgets/register', [ $this, 'register_widgets' ]);
+    }
+
+    public function register_widgets( $widgets_manager ) {
+        $files = glob( __DIR__ . '/widgets/class-bw-*-widget.php' );
+        foreach ( $files as $file ) {
+            require_once $file;
+            $class_name = $this->get_class_from_file($file);
+            if ( class_exists($class_name) ) {
+                $widgets_manager->register( new $class_name() );
+            }
+        }
+    }
+
+    private function get_class_from_file( $file ) {
+        $basename = basename($file, '.php');
+        // es: class-bw-products-slide-widget.php → Widget_Bw_Products_Slide
+        $parts = explode('-', str_replace('class-', '', $basename));
+        $class = 'Widget_';
+        foreach ($parts as $p) {
+            $class .= ucfirst($p) . '_';
+        }
+        return rtrim($class, '_');
+    }
+}
+
+new BW_Widget_Loader();

--- a/bw-elementor-widgets/includes/widgets/class-bw-products-slide-widget.php
+++ b/bw-elementor-widgets/includes/widgets/class-bw-products-slide-widget.php
@@ -1,0 +1,86 @@
+<?php
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+class Widget_Bw_Products_Slide extends Widget_Base {
+
+    public function get_name() { return 'bw_products_slide'; }
+    public function get_title() { return 'BW Products Slide'; }
+    public function get_icon() { return 'eicon-slider-full-screen'; }
+    public function get_categories() { return [ 'general' ]; }
+
+    public function get_script_depends() {
+        return [ 'flickity-js', 'bw-products-slide-script' ];
+    }
+
+    public function get_style_depends() {
+        return [ 'flickity-css', 'bw-products-slide-style' ];
+    }
+
+    protected function register_controls() {
+        // Query Section
+        $this->start_controls_section('query_section', [
+            'label' => __( 'Query', 'plugin-name' ),
+        ]);
+        $this->add_control('post_type', [ 'label' => 'Post Type', 'type' => Controls_Manager::TEXT, 'default' => 'post' ]);
+        $this->add_control('category', [ 'label' => 'Category', 'type' => Controls_Manager::TEXT, 'default' => '' ]);
+        $this->add_control('include_ids', [ 'label' => 'Include IDs', 'type' => Controls_Manager::TEXT, 'default' => '' ]);
+        $this->end_controls_section();
+
+        // Display Section
+        $this->start_controls_section('display_section', [ 'label' => 'Display Options' ]);
+        $this->add_control('show_title', [ 'label' => 'Mostra titolo', 'type' => Controls_Manager::SWITCHER, 'default' => 'yes' ]);
+        $this->add_control('show_subtitle', [ 'label' => 'Mostra sottotitolo', 'type' => Controls_Manager::SWITCHER, 'default' => 'yes' ]);
+        $this->add_control('show_price', [ 'label' => 'Mostra prezzo', 'type' => Controls_Manager::SWITCHER, 'default' => '' ]);
+        $this->end_controls_section();
+
+        // Layout Section
+        $this->start_controls_section('layout_section', [ 'label' => 'Layout' ]);
+        $this->add_control('columns', [ 'label' => 'Colonne', 'type' => Controls_Manager::SLIDER, 'range' => ['px' => ['min'=>2,'max'=>6]], 'default' => ['size'=>3] ]);
+        $this->add_control('gap', [ 'label' => 'Spazio tra colonne (px)', 'type' => Controls_Manager::NUMBER, 'default' => 20 ]);
+        $this->end_controls_section();
+
+        // Slider Section
+        $this->start_controls_section('slider_section', [ 'label' => 'Slider Settings' ]);
+        $this->add_control('autoplay_speed', [ 'label' => 'Autoplay Speed (ms)', 'type' => Controls_Manager::NUMBER, 'default' => 3000 ]);
+        $this->add_control('wrap_around', [ 'label' => 'Loop infinito', 'type' => Controls_Manager::SWITCHER, 'default' => 'yes' ]);
+        $this->add_control('fade', [ 'label' => 'Effetto Fade', 'type' => Controls_Manager::SWITCHER, 'default' => '' ]);
+        $this->end_controls_section();
+    }
+
+    protected function render() {
+        $settings = $this->get_settings_for_display();
+        $args = [ 'post_type' => $settings['post_type'], 'posts_per_page' => -1 ];
+        if ($settings['category']) { $args['category_name'] = $settings['category']; }
+        if ($settings['include_ids']) { $args['post__in'] = array_map('intval', explode(',', $settings['include_ids'])); }
+
+        $query = new \WP_Query($args);
+        echo '<div class="bw-products-slider"
+                data-columns="'.esc_attr($settings['columns']['size']).'"
+                data-gap="'.esc_attr($settings['gap']).'"
+                data-autoplay="'.esc_attr($settings['autoplay_speed']).'"
+                data-wrap="'.esc_attr($settings['wrap_around']).'"
+                data-fade="'.esc_attr($settings['fade']).'">';
+
+        while ($query->have_posts()) : $query->the_post();
+            echo '<div class="carousel-cell">';
+                if (has_post_thumbnail()) {
+                    echo '<img src="'.get_the_post_thumbnail_url(get_the_ID(),'medium').'" alt="'.get_the_title().'">';
+                }
+                echo '<div class="caption">';
+                    if ($settings['show_title']) { echo '<h4>'.get_the_title().'</h4>'; }
+                    if ($settings['show_subtitle']) { echo '<p>'.get_the_excerpt().'</p>'; }
+                    if ($settings['show_price'] && function_exists('wc_get_product')) {
+                        $product = wc_get_product(get_the_ID());
+                        if ($product) echo '<span class="price">'.$product->get_price_html().'</span>';
+                    }
+                echo '</div>';
+            echo '</div>';
+        endwhile;
+
+        echo '</div>';
+        wp_reset_postdata();
+    }
+}


### PR DESCRIPTION
## Summary
- add the BW Elementor Widgets plugin scaffolding with loader and assets
- include the BW Products Slide widget implementation with Flickity dependencies
- document folder layout and usage in the plugin README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6bfa3410c8325a85654a7df0fe0e4