### PR TITLE
Fix BW Products Slide widget registration and assets

### DIFF
--- a/bw-elementor-widgets/assets/js/bw-products-slide.js
+++ b/bw-elementor-widgets/assets/js/bw-products-slide.js
@@ -1,18 +1,41 @@
-jQuery(document).ready(function($){
-  $('.bw-products-slider').each(function(){
-    let el = $(this);
+jQuery(document).ready(function ($) {
+  $('.bw-products-slider').each(function () {
+    var $slider = $(this);
 
-    let autoplay = el.data('autoplay');
-    let wrap = el.data('wrap') === 'yes';
-    let fade = el.data('fade') === 'yes';
+    var columns = parseInt($slider.data('columns'), 10);
+    var gap = parseInt($slider.data('gap'), 10);
+    var autoplay = parseInt($slider.data('autoplay'), 10);
+    var wrap = $slider.data('wrap') === 'yes';
+    var fade = $slider.data('fade') === 'yes';
 
-    el.flickity({
+    if (isNaN(columns) || columns < 1) {
+      columns = 1;
+    }
+
+    if (isNaN(gap)) {
+      gap = 0;
+    }
+
+    if (isNaN(autoplay) || autoplay <= 0) {
+      autoplay = false;
+    }
+
+    $slider.find('.carousel-cell').css('margin-right', gap + 'px');
+
+    var flickityOptions = {
       cellAlign: 'left',
       contain: true,
-      groupCells: true,
-      autoPlay: autoplay ? autoplay : false,
+      groupCells: columns > 1 ? columns : 1,
+      autoPlay: autoplay,
       wrapAround: wrap,
-      fade: fade
-    });
+      fade: fade,
+      pageDots: false
+    };
+
+    if (fade) {
+      flickityOptions.groupCells = false;
+    }
+
+    $slider.flickity(flickityOptions);
   });
 });

--- a/bw-elementor-widgets/bw-main-elementor-widgets.php
+++ b/bw-elementor-widgets/bw-main-elementor-widgets.php
@@ -6,15 +6,47 @@
  * Author: Simone
  */
 
-if ( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
 // Loader dei widget
 require_once __DIR__ . '/includes/class-bw-widget-loader.php';
 
-// Registrazione eventuali asset globali
+// Registrazione asset condivisi tra i widget
 function bw_widgets_register_assets() {
-    // Se vuoi aggiungere un CSS/JS condiviso tra tutti i widget
-    // wp_register_style('bw-widgets-global', plugins_url('/assets/css/global.css', __FILE__));
-    // wp_enqueue_style('bw-widgets-global');
+    $plugin_url = plugin_dir_url( __FILE__ );
+
+    wp_register_style(
+        'flickity-css',
+        'https://unpkg.com/flickity@2.3.0/dist/flickity.css',
+        [],
+        '2.3.0'
+    );
+
+    wp_register_script(
+        'flickity-js',
+        'https://unpkg.com/flickity@2.3.0/dist/flickity.pkgd.min.js',
+        [],
+        '2.3.0',
+        true
+    );
+
+    wp_register_style(
+        'bw-products-slide-style',
+        $plugin_url . 'assets/css/bw-products-slide.css',
+        [],
+        '1.0.0'
+    );
+
+    wp_register_script(
+        'bw-products-slide-script',
+        $plugin_url . 'assets/js/bw-products-slide.js',
+        [ 'jquery', 'flickity-js' ],
+        '1.0.0',
+        true
+    );
 }
-add_action('wp_enqueue_scripts', 'bw_widgets_register_assets');
+add_action( 'elementor/frontend/after_register_styles', 'bw_widgets_register_assets' );
+add_action( 'elementor/frontend/after_register_scripts', 'bw_widgets_register_assets' );
+add_action( 'wp_enqueue_scripts', 'bw_widgets_register_assets' );

--- a/bw-elementor-widgets/includes/class-bw-widget-loader.php
+++ b/bw-elementor-widgets/includes/class-bw-widget-loader.php
@@ -1,31 +1,44 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
 class BW_Widget_Loader {
     public function __construct() {
-        add_action('elementor/widgets/register', [ $this, 'register_widgets' ]);
+        add_action( 'elementor/widgets/register', [ $this, 'register_widgets' ] );
+        add_action( 'elementor/widgets/widgets_registered', [ $this, 'register_widgets' ] );
     }
 
-    public function register_widgets( $widgets_manager ) {
+    public function register_widgets( $widgets_manager = null ) {
+        if ( null === $widgets_manager && class_exists( '\\Elementor\\Plugin' ) ) {
+            $widgets_manager = \Elementor\Plugin::instance()->widgets_manager;
+        }
+
+        if ( ! $widgets_manager ) {
+            return;
+        }
+
         $files = glob( __DIR__ . '/widgets/class-bw-*-widget.php' );
         foreach ( $files as $file ) {
             require_once $file;
-            $class_name = $this->get_class_from_file($file);
-            if ( class_exists($class_name) ) {
+            $class_name = $this->get_class_from_file( $file );
+            if ( class_exists( $class_name ) ) {
                 $widgets_manager->register( new $class_name() );
             }
         }
     }
 
     private function get_class_from_file( $file ) {
-        $basename = basename($file, '.php');
-        // es: class-bw-products-slide-widget.php → Widget_Bw_Products_Slide
-        $parts = explode('-', str_replace('class-', '', $basename));
-        $class = 'Widget_';
-        foreach ($parts as $p) {
-            $class .= ucfirst($p) . '_';
-        }
-        return rtrim($class, '_');
+        $basename = basename( $file, '.php' );
+        $basename = preg_replace( '/^class-/', '', $basename );
+        $basename = preg_replace( '/-widget$/', '', $basename );
+
+        $parts = array_filter( explode( '-', $basename ) );
+        $parts = array_map( static function( $part ) {
+            return ucfirst( $part );
+        }, $parts );
+
+        return 'Widget_' . implode( '_', $parts );
     }
 }
 

--- a/bw-elementor-widgets/includes/widgets/class-bw-products-slide-widget.php
+++ b/bw-elementor-widgets/includes/widgets/class-bw-products-slide-widget.php
@@ -1,15 +1,28 @@
 <?php
-use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
+use Elementor\Widget_Base;
 
-if ( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
 class Widget_Bw_Products_Slide extends Widget_Base {
 
-    public function get_name() { return 'bw_products_slide'; }
-    public function get_title() { return 'BW Products Slide'; }
-    public function get_icon() { return 'eicon-slider-full-screen'; }
-    public function get_categories() { return [ 'general' ]; }
+    public function get_name() {
+        return 'bw_products_slide';
+    }
+
+    public function get_title() {
+        return 'BW Products Slide';
+    }
+
+    public function get_icon() {
+        return 'eicon-slider-full-screen';
+    }
+
+    public function get_categories() {
+        return [ 'general' ];
+    }
 
     public function get_script_depends() {
         return [ 'flickity-js', 'bw-products-slide-script' ];
@@ -21,66 +34,180 @@ class Widget_Bw_Products_Slide extends Widget_Base {
 
     protected function register_controls() {
         // Query Section
-        $this->start_controls_section('query_section', [
-            'label' => __( 'Query', 'plugin-name' ),
-        ]);
-        $this->add_control('post_type', [ 'label' => 'Post Type', 'type' => Controls_Manager::TEXT, 'default' => 'post' ]);
-        $this->add_control('category', [ 'label' => 'Category', 'type' => Controls_Manager::TEXT, 'default' => '' ]);
-        $this->add_control('include_ids', [ 'label' => 'Include IDs', 'type' => Controls_Manager::TEXT, 'default' => '' ]);
+        $this->start_controls_section( 'query_section', [
+            'label' => __( 'Query', 'bw-elementor-widgets' ),
+        ] );
+
+        $this->add_control( 'post_type', [
+            'label'   => __( 'Post Type', 'bw-elementor-widgets' ),
+            'type'    => Controls_Manager::TEXT,
+            'default' => 'post',
+        ] );
+
+        $this->add_control( 'category', [
+            'label'   => __( 'Category', 'bw-elementor-widgets' ),
+            'type'    => Controls_Manager::TEXT,
+            'default' => '',
+        ] );
+
+        $this->add_control( 'include_ids', [
+            'label'       => __( 'Include IDs', 'bw-elementor-widgets' ),
+            'type'        => Controls_Manager::TEXT,
+            'description' => __( 'Inserisci gli ID separati da virgola', 'bw-elementor-widgets' ),
+            'default'     => '',
+        ] );
+
         $this->end_controls_section();
 
         // Display Section
-        $this->start_controls_section('display_section', [ 'label' => 'Display Options' ]);
-        $this->add_control('show_title', [ 'label' => 'Mostra titolo', 'type' => Controls_Manager::SWITCHER, 'default' => 'yes' ]);
-        $this->add_control('show_subtitle', [ 'label' => 'Mostra sottotitolo', 'type' => Controls_Manager::SWITCHER, 'default' => 'yes' ]);
-        $this->add_control('show_price', [ 'label' => 'Mostra prezzo', 'type' => Controls_Manager::SWITCHER, 'default' => '' ]);
+        $this->start_controls_section( 'display_section', [
+            'label' => __( 'Display Options', 'bw-elementor-widgets' ),
+        ] );
+
+        $this->add_control( 'show_title', [
+            'label'   => __( 'Mostra titolo', 'bw-elementor-widgets' ),
+            'type'    => Controls_Manager::SWITCHER,
+            'default' => 'yes',
+        ] );
+
+        $this->add_control( 'show_subtitle', [
+            'label'   => __( 'Mostra sottotitolo', 'bw-elementor-widgets' ),
+            'type'    => Controls_Manager::SWITCHER,
+            'default' => 'yes',
+        ] );
+
+        $this->add_control( 'show_price', [
+            'label'   => __( 'Mostra prezzo', 'bw-elementor-widgets' ),
+            'type'    => Controls_Manager::SWITCHER,
+            'default' => '',
+        ] );
+
         $this->end_controls_section();
 
         // Layout Section
-        $this->start_controls_section('layout_section', [ 'label' => 'Layout' ]);
-        $this->add_control('columns', [ 'label' => 'Colonne', 'type' => Controls_Manager::SLIDER, 'range' => ['px' => ['min'=>2,'max'=>6]], 'default' => ['size'=>3] ]);
-        $this->add_control('gap', [ 'label' => 'Spazio tra colonne (px)', 'type' => Controls_Manager::NUMBER, 'default' => 20 ]);
+        $this->start_controls_section( 'layout_section', [
+            'label' => __( 'Layout', 'bw-elementor-widgets' ),
+        ] );
+
+        $this->add_control( 'columns', [
+            'label'   => __( 'Colonne', 'bw-elementor-widgets' ),
+            'type'    => Controls_Manager::SLIDER,
+            'size_units' => [ 'px' ],
+            'range'   => [
+                'px' => [
+                    'min' => 1,
+                    'max' => 6,
+                ],
+            ],
+            'default' => [
+                'size' => 3,
+            ],
+        ] );
+
+        $this->add_control( 'gap', [
+            'label'   => __( 'Spazio tra colonne (px)', 'bw-elementor-widgets' ),
+            'type'    => Controls_Manager::NUMBER,
+            'default' => 20,
+        ] );
+
         $this->end_controls_section();
 
         // Slider Section
-        $this->start_controls_section('slider_section', [ 'label' => 'Slider Settings' ]);
-        $this->add_control('autoplay_speed', [ 'label' => 'Autoplay Speed (ms)', 'type' => Controls_Manager::NUMBER, 'default' => 3000 ]);
-        $this->add_control('wrap_around', [ 'label' => 'Loop infinito', 'type' => Controls_Manager::SWITCHER, 'default' => 'yes' ]);
-        $this->add_control('fade', [ 'label' => 'Effetto Fade', 'type' => Controls_Manager::SWITCHER, 'default' => '' ]);
+        $this->start_controls_section( 'slider_section', [
+            'label' => __( 'Slider Settings', 'bw-elementor-widgets' ),
+        ] );
+
+        $this->add_control( 'autoplay_speed', [
+            'label'   => __( 'Autoplay Speed (ms)', 'bw-elementor-widgets' ),
+            'type'    => Controls_Manager::NUMBER,
+            'default' => 3000,
+        ] );
+
+        $this->add_control( 'wrap_around', [
+            'label'   => __( 'Loop infinito', 'bw-elementor-widgets' ),
+            'type'    => Controls_Manager::SWITCHER,
+            'default' => 'yes',
+        ] );
+
+        $this->add_control( 'fade', [
+            'label'   => __( 'Effetto Fade', 'bw-elementor-widgets' ),
+            'type'    => Controls_Manager::SWITCHER,
+            'default' => '',
+        ] );
+
         $this->end_controls_section();
     }
 
     protected function render() {
         $settings = $this->get_settings_for_display();
-        $args = [ 'post_type' => $settings['post_type'], 'posts_per_page' => -1 ];
-        if ($settings['category']) { $args['category_name'] = $settings['category']; }
-        if ($settings['include_ids']) { $args['post__in'] = array_map('intval', explode(',', $settings['include_ids'])); }
 
-        $query = new \WP_Query($args);
-        echo '<div class="bw-products-slider"
-                data-columns="'.esc_attr($settings['columns']['size']).'"
-                data-gap="'.esc_attr($settings['gap']).'"
-                data-autoplay="'.esc_attr($settings['autoplay_speed']).'"
-                data-wrap="'.esc_attr($settings['wrap_around']).'"
-                data-fade="'.esc_attr($settings['fade']).'">';
+        $args = [
+            'post_type'      => ! empty( $settings['post_type'] ) ? $settings['post_type'] : 'post',
+            'posts_per_page' => -1,
+        ];
 
-        while ($query->have_posts()) : $query->the_post();
-            echo '<div class="carousel-cell">';
-                if (has_post_thumbnail()) {
-                    echo '<img src="'.get_the_post_thumbnail_url(get_the_ID(),'medium').'" alt="'.get_the_title().'">';
+        if ( ! empty( $settings['category'] ) ) {
+            $args['category_name'] = $settings['category'];
+        }
+
+        if ( ! empty( $settings['include_ids'] ) ) {
+            $ids = array_map( 'intval', array_filter( array_map( 'trim', explode( ',', $settings['include_ids'] ) ) ) );
+            if ( $ids ) {
+                $args['post__in'] = $ids;
+            }
+        }
+
+        $query = new \WP_Query( $args );
+
+        $columns  = isset( $settings['columns']['size'] ) ? (int) $settings['columns']['size'] : 3;
+        $gap      = isset( $settings['gap'] ) ? (int) $settings['gap'] : 20;
+        $autoplay = isset( $settings['autoplay_speed'] ) ? (int) $settings['autoplay_speed'] : 0;
+        $wrap     = ( isset( $settings['wrap_around'] ) && 'yes' === $settings['wrap_around'] ) ? 'yes' : 'no';
+        $fade     = ( isset( $settings['fade'] ) && 'yes' === $settings['fade'] ) ? 'yes' : 'no';
+
+        if ( $query->have_posts() ) {
+            echo '<div class="bw-products-slider"'
+                . ' data-columns="' . esc_attr( $columns ) . '"'
+                . ' data-gap="' . esc_attr( $gap ) . '"'
+                . ' data-autoplay="' . esc_attr( $autoplay ) . '"'
+                . ' data-wrap="' . esc_attr( $wrap ) . '"'
+                . ' data-fade="' . esc_attr( $fade ) . '">';
+
+            while ( $query->have_posts() ) {
+                $query->the_post();
+
+                echo '<div class="carousel-cell">';
+
+                if ( has_post_thumbnail() ) {
+                    echo '<img src="' . esc_url( get_the_post_thumbnail_url( get_the_ID(), 'medium' ) ) . '" alt="' . esc_attr( get_the_title() ) . '">';
                 }
-                echo '<div class="caption">';
-                    if ($settings['show_title']) { echo '<h4>'.get_the_title().'</h4>'; }
-                    if ($settings['show_subtitle']) { echo '<p>'.get_the_excerpt().'</p>'; }
-                    if ($settings['show_price'] && function_exists('wc_get_product')) {
-                        $product = wc_get_product(get_the_ID());
-                        if ($product) echo '<span class="price">'.$product->get_price_html().'</span>';
-                    }
-                echo '</div>';
-            echo '</div>';
-        endwhile;
 
-        echo '</div>';
-        wp_reset_postdata();
+                echo '<div class="caption">';
+
+                if ( ! empty( $settings['show_title'] ) ) {
+                    echo '<h4>' . esc_html( get_the_title() ) . '</h4>';
+                }
+
+                if ( ! empty( $settings['show_subtitle'] ) ) {
+                    echo '<p>' . esc_html( get_the_excerpt() ) . '</p>';
+                }
+
+                if ( ! empty( $settings['show_price'] ) && function_exists( 'wc_get_product' ) ) {
+                    $product = wc_get_product( get_the_ID() );
+                    if ( $product ) {
+                        echo '<span class="price">' . wp_kses_post( $product->get_price_html() ) . '</span>';
+                    }
+                }
+
+                echo '</div>';
+                echo '</div>';
+            }
+
+            echo '</div>';
+
+            wp_reset_postdata();
+        } else {
+            echo '<p>' . esc_html__( 'Nessun contenuto trovato.', 'bw-elementor-widgets' ) . '</p>';
+        }
     }
 }


### PR DESCRIPTION
## Summary
- register Flickity and widget assets with Elementor hooks so the BW Products Slide widget loads its dependencies
- correct the widget loader class-name mapping and add a fallback Elementor hook to ensure registration
- align the BW Products Slide widget and JavaScript to expose configuration data attributes and initialise Flickity accordingly

## Testing
- php -l bw-elementor-widgets/bw-main-elementor-widgets.php
- php -l bw-elementor-widgets/includes/class-bw-widget-loader.php
- php -l bw-elementor-widgets/includes/widgets/class-bw-products-slide-widget.php

------
https://chatgpt.com/codex/tasks/task_e_68d6c8518a648325a68ca2db29d24b10