### PR TITLE
Fix BW Products Slide widget registration

### DIFF
--- a/bw-elementor-widgets/bw-main-elementor-widgets.php
+++ b/bw-elementor-widgets/bw-main-elementor-widgets.php
@@ -56,4 +56,6 @@ function bw_widgets_register_assets() {
 }
 add_action( 'elementor/frontend/after_register_styles', 'bw_widgets_register_assets' );
 add_action( 'elementor/frontend/after_register_scripts', 'bw_widgets_register_assets' );
+add_action( 'elementor/editor/after_enqueue_styles', 'bw_widgets_register_assets' );
+add_action( 'elementor/editor/after_enqueue_scripts', 'bw_widgets_register_assets' );
 add_action( 'wp_enqueue_scripts', 'bw_widgets_register_assets' );


### PR DESCRIPTION
## Summary
- guard the widget loader so it only instantiates Elementor widgets after Elementor is loaded
- normalise loader discovery to avoid false negatives and register widgets using either modern or legacy Elementor APIs
- register shared assets during Elementor editor requests so Flickity scripts/styles are always available

## Testing
- php -l bw-elementor-widgets/includes/class-bw-widget-loader.php
- php -l bw-elementor-widgets/bw-main-elementor-widgets.php

------
https://chatgpt.com/codex/tasks/task_e_68d6df885b048325ab83b7145ff1a602