### PR TITLE
Register widget loader hooks for Elementor

### DIFF
--- a/bw-elementor-widgets/includes/class-bw-widget-loader.php
+++ b/bw-elementor-widgets/includes/class-bw-widget-loader.php
@@ -13,7 +13,10 @@ class BW_Widget_Loader {
      */
     private $widgets_registered = false;
 
-    private function __construct() {}
+    private function __construct() {
+        add_action( 'elementor/widgets/register', [ $this, 'register_widgets' ] );
+        add_action( 'elementor/widgets/widgets_registered', [ $this, 'register_widgets' ] );
+    }
 
     public static function instance() {
         if ( null === self::$instance ) {
@@ -78,3 +81,5 @@ class BW_Widget_Loader {
         return 'Widget_' . implode( '_', $parts );
     }
 }
+
+BW_Widget_Loader::instance();


### PR DESCRIPTION
## Summary
- hook `BW_Widget_Loader` into Elementor's widget registration and fallback actions
- instantiate the loader on include so Elementor widgets are registered once

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6e953d6dc8325a1d42fb67043ebd1