### PR TITLE
Force manual registration of BW Products Slide widget

### DIFF
--- a/bw-elementor-widgets/bw-main-elementor-widgets.php
+++ b/bw-elementor-widgets/bw-main-elementor-widgets.php
@@ -13,6 +13,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Loader dei widget
 require_once __DIR__ . '/includes/class-bw-widget-loader.php';
 
+add_action( 'elementor/widgets/register', function( $widgets_manager ) {
+    require_once __DIR__ . '/includes/widgets/class-bw-products-slide-widget.php';
+    $widgets_manager->register( new Widget_Bw_Products_Slide() );
+} );
+
 // Registrazione widget Elementor
 function bw_widgets_register_elementor_widgets( $widgets_manager = null ) {
     BW_Widget_Loader::instance()->register_widgets( $widgets_manager );


### PR DESCRIPTION
## Summary
- ensure the BW Products Slide widget is required and registered directly on the Elementor widgets register hook
- keep the existing loader in place for future widgets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7068a5fa88325bbcaeb32e8cb3056