### PR TITLE
Fix BW Products Slide widget registration and assets

### DIFF
--- a/bw-main-elementor-widgets.php
+++ b/bw-main-elementor-widgets.php
@@ -6,13 +6,18 @@
  * Author: Simone
  */
 
-if ( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
 // Loader dei widget
 require_once __DIR__ . '/includes/class-bw-widget-loader.php';
 
 // Registrazione eventuali asset globali
 function bw_widgets_register_assets() {
+    $plugin_dir_url  = plugin_dir_url( __FILE__ );
+    $plugin_dir_path = plugin_dir_path( __FILE__ );
+
     // Flickity
     wp_register_style(
         'flickity-css',
@@ -29,31 +34,42 @@ function bw_widgets_register_assets() {
         true
     );
 
+    $style_path  = $plugin_dir_path . 'assets/css/bw-products-slide.css';
+    $style_ver   = file_exists( $style_path ) ? filemtime( $style_path ) : null;
+    $script_path = $plugin_dir_path . 'assets/js/bw-products-slide.js';
+    $script_ver  = file_exists( $script_path ) ? filemtime( $script_path ) : null;
+
     // Widget assets
     wp_register_style(
         'bw-products-slide-style',
-        plugins_url('/assets/css/bw-products-slide.css', __FILE__)
+        $plugin_dir_url . 'assets/css/bw-products-slide.css',
+        [],
+        $style_ver
     );
 
     wp_register_script(
         'bw-products-slide-script',
-        plugins_url('/assets/js/bw-products-slide.js', __FILE__),
-        ['jquery', 'flickity-js'],
-        '1.0',
+        $plugin_dir_url . 'assets/js/bw-products-slide.js',
+        [ 'jquery', 'flickity-js' ],
+        $script_ver,
         true
     );
 }
-add_action('wp_enqueue_scripts', 'bw_widgets_register_assets');
-add_action('elementor/frontend/after_register_styles', 'bw_widgets_register_assets');
-add_action('elementor/frontend/after_register_scripts', 'bw_widgets_register_assets');
+add_action( 'wp_enqueue_scripts', 'bw_widgets_register_assets' );
+add_action( 'elementor/frontend/after_register_styles', 'bw_widgets_register_assets' );
+add_action( 'elementor/frontend/after_register_scripts', 'bw_widgets_register_assets' );
 
 // Aggiungi categoria personalizzata "Black Work"
-add_action( 'elementor/elements/categories_registered', function( $elements_manager ) {
+add_action( 'elementor/elements/categories_registered', static function( $elements_manager ) {
+    if ( ! method_exists( $elements_manager, 'add_category' ) ) {
+        return;
+    }
+
     $elements_manager->add_category(
         'black-work',
         [
             'title' => __( 'Black Work', 'bw-elementor-widgets' ),
-            'icon' => 'fa fa-cube',
+            'icon'  => 'fa fa-cube',
         ]
     );
-});
+} );

--- a/includes/class-bw-widget-loader.php
+++ b/includes/class-bw-widget-loader.php
@@ -47,9 +47,12 @@ class BW_Widget_Loader {
         foreach ( $files as $file ) {
             require_once $file;
             $class_name = $this->get_class_from_file( $file );
-            if ( class_exists( $class_name ) ) {
-                $this->register_widget_with_manager( $widgets_manager, $class_name );
+
+            if ( ! $class_name || ! class_exists( $class_name ) ) {
+                continue;
             }
+
+            $this->register_widget_with_manager( $widgets_manager, $class_name );
         }
 
         $this->widgets_registered = true;
@@ -69,14 +72,20 @@ class BW_Widget_Loader {
     }
 
     private function get_class_from_file( $file ) {
-        $basename = basename( $file, '.php' );
-        $basename = preg_replace( '/^class-/', '', $basename );
-        $basename = preg_replace( '/-widget$/', '', $basename );
+        $basename = basename( $file );
 
-        $parts = array_filter( explode( '-', $basename ) );
+        if ( ! preg_match( '/^class-(.+)-widget\.php$/', $basename, $matches ) ) {
+            return '';
+        }
+
+        $parts = array_filter( explode( '-', $matches[1] ) );
         $parts = array_map( static function( $part ) {
             return ucfirst( $part );
         }, $parts );
+
+        if ( empty( $parts ) ) {
+            return '';
+        }
 
         return 'Widget_' . implode( '_', $parts );
     }

--- a/includes/widgets/class-bw-products-slide-widget.php
+++ b/includes/widgets/class-bw-products-slide-widget.php
@@ -2,7 +2,9 @@
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 
-if ( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
 
 class Widget_Bw_Products_Slide extends Widget_Base {
 


### PR DESCRIPTION
## Summary
- ensure the Elementor plugin registers Flickity assets, hooks, and custom Black Work category
- harden the widget loader to resolve widget classes reliably before registration
- confirm the BW Products Slide widget metadata matches the new category and dependencies

## Testing
- php -l wpblackwork/bw-main-elementor-widgets.php
- php -l wpblackwork/includes/class-bw-widget-loader.php
- php -l wpblackwork/includes/widgets/class-bw-products-slide-widget.php

------
https://chatgpt.com/codex/tasks/task_e_68d70f1027748325a284a8930a9de2b9