### PR TITLE
Improve BW products slider initialization

### DIFF
--- a/assets/js/bw-products-slide.js
+++ b/assets/js/bw-products-slide.js
@@ -1,48 +1,84 @@
-jQuery(document).ready(function ($) {
-  $('.bw-products-slider').each(function () {
-    var $slider = $(this);
-
-    var columns = parseInt($slider.data('columns'), 10);
-    var gap = parseInt($slider.data('gap'), 10);
-    var autoplayEnabled = $slider.data('autoPlay') === 'yes';
-    var autoplaySpeed = parseInt($slider.data('autoPlaySpeed'), 10);
-    var prevNextButtons = $slider.data('prevNextButtons') === 'yes';
-    var pageDots = $slider.data('pageDots') === 'yes';
-    var wrapAround = $slider.data('wrapAround') === 'yes';
-    var fade = $slider.data('fade') === 'yes';
-
-    if (isNaN(columns) || columns < 1) {
-      columns = 1;
+(function ($) {
+  function parseBoolean(value) {
+    if (value === undefined || value === null) {
+      return false;
     }
 
-    if ($slider.length) {
-      if (!isNaN(gap)) {
-        $slider[0].style.setProperty('--gap', gap + 'px');
+    if (typeof value === 'string') {
+      value = value.toLowerCase();
+      return value === 'true' || value === '1' || value === 'yes';
+    }
+
+    return Boolean(value);
+  }
+
+  function initBwProductsSlider($scope) {
+    var $sliders = $scope.find('.bw-products-slider');
+
+    if (!$sliders.length) {
+      return;
+    }
+
+    $sliders.each(function () {
+      var $slider = $(this);
+
+      if ($slider.hasClass('is-initialized')) {
+        return;
       }
 
-      $slider[0].style.setProperty('--columns', columns);
-    }
+      $slider.addClass('is-initialized');
 
-    var autoplay = false;
-    if (autoplayEnabled) {
-      autoplay = !isNaN(autoplaySpeed) && autoplaySpeed > 0 ? autoplaySpeed : 3000;
-    }
+      var columns = parseInt($slider.data('columns'), 10);
+      var gap = parseInt($slider.data('gap'), 10);
 
-    var flickityOptions = {
-      cellAlign: 'left',
-      contain: true,
-      groupCells: columns > 1 ? columns : 1,
-      autoPlay: autoplay,
-      wrapAround: wrapAround,
-      fade: fade,
-      prevNextButtons: prevNextButtons,
-      pageDots: pageDots
-    };
+      if (isNaN(columns) || columns < 1) {
+        columns = 1;
+      }
 
-    if (fade) {
-      flickityOptions.groupCells = false;
-    }
+      if ($slider.length) {
+        if (!isNaN(gap)) {
+          $slider[0].style.setProperty('--gap', gap + 'px');
+        }
 
-    $slider.flickity(flickityOptions);
+        $slider[0].style.setProperty('--columns', columns);
+      }
+
+      var autoplayAttr = $slider.data('autoplay');
+      var autoplay = false;
+
+      if (autoplayAttr !== undefined && autoplayAttr !== '' && autoplayAttr !== false) {
+        var autoplayValue = parseInt(autoplayAttr, 10);
+        autoplay = !isNaN(autoplayValue) && autoplayValue > 0 ? autoplayValue : false;
+      }
+
+      var fade = parseBoolean($slider.data('fade'));
+
+      var flickityOptions = {
+        cellAlign: 'left',
+        contain: true,
+        groupCells: columns > 1 ? columns : 1,
+        autoPlay: autoplay,
+        wrapAround: parseBoolean($slider.data('wrap')),
+        fade: fade,
+        prevNextButtons: parseBoolean($slider.data('arrows')),
+        pageDots: parseBoolean($slider.data('dots'))
+      };
+
+      if (fade) {
+        flickityOptions.groupCells = false;
+      }
+
+      $slider.flickity(flickityOptions);
+    });
+  }
+
+  $(function () {
+    initBwProductsSlider($(document));
   });
-});
+
+  jQuery(window).on('elementor/frontend/init', function () {
+    elementorFrontend.hooks.addAction('frontend/element_ready/bw_products_slide.default', initBwProductsSlider);
+  });
+
+  window.initBwProductsSlider = initBwProductsSlider;
+})(jQuery);


### PR DESCRIPTION
## Summary
- create a reusable `initBwProductsSlider` initializer that prevents double Flickity setups
- hook the initializer into Elementor and document-ready flows while mapping data attributes to Flickity options

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7a1e677888325823359d179ce235f