### PR TITLE
Ensure BW products slider initializes in Elementor editor

### DIFF
--- a/assets/js/bw-products-slide.js
+++ b/assets/js/bw-products-slide.js
@@ -1,48 +1,75 @@
-jQuery(document).ready(function ($) {
-  $('.bw-products-slider').each(function () {
-    var $slider = $(this);
+(function ($) {
+  function parseBoolean(value) {
+    return value === true || value === 'true' || value === '1' || value === 1 || value === 'yes';
+  }
 
-    var columns = parseInt($slider.data('columns'), 10);
-    var gap = parseInt($slider.data('gap'), 10);
-    var autoplayEnabled = $slider.data('autoPlay') === 'yes';
-    var autoplaySpeed = parseInt($slider.data('autoPlaySpeed'), 10);
-    var prevNextButtons = $slider.data('prevNextButtons') === 'yes';
-    var pageDots = $slider.data('pageDots') === 'yes';
-    var wrapAround = $slider.data('wrapAround') === 'yes';
-    var fade = $slider.data('fade') === 'yes';
+  function initBwProductsSlider($scope) {
+    var $sliders = $scope.find('.bw-products-slider');
 
-    if (isNaN(columns) || columns < 1) {
-      columns = 1;
+    if (!$sliders.length) {
+      return;
     }
 
-    if ($slider.length) {
+    $sliders.each(function () {
+      var $slider = $(this);
+
+      if ($slider.hasClass('is-initialized')) {
+        return;
+      }
+
+      var columns = parseInt($slider.data('columns'), 10);
+      var gap = parseInt($slider.data('gap'), 10);
+      var autoplayData = $slider.data('autoplay');
+      var arrows = parseBoolean($slider.data('arrows'));
+      var dots = parseBoolean($slider.data('dots'));
+      var wrap = parseBoolean($slider.data('wrap'));
+      var fade = parseBoolean($slider.data('fade'));
+
+      if (isNaN(columns) || columns < 1) {
+        columns = 1;
+      }
+
       if (!isNaN(gap)) {
         $slider[0].style.setProperty('--gap', gap + 'px');
       }
 
       $slider[0].style.setProperty('--columns', columns);
-    }
 
-    var autoplay = false;
-    if (autoplayEnabled) {
-      autoplay = !isNaN(autoplaySpeed) && autoplaySpeed > 0 ? autoplaySpeed : 3000;
-    }
+      var autoplay = false;
 
-    var flickityOptions = {
-      cellAlign: 'left',
-      contain: true,
-      groupCells: columns > 1 ? columns : 1,
-      autoPlay: autoplay,
-      wrapAround: wrapAround,
-      fade: fade,
-      prevNextButtons: prevNextButtons,
-      pageDots: pageDots
-    };
+      if (autoplayData !== undefined && autoplayData !== '' && autoplayData !== false) {
+        var autoplayValue = parseInt(autoplayData, 10);
 
-    if (fade) {
-      flickityOptions.groupCells = false;
-    }
+        autoplay = !isNaN(autoplayValue) && autoplayValue > 0 ? autoplayValue : false;
+      }
 
-    $slider.flickity(flickityOptions);
+      var flickityOptions = {
+        cellAlign: 'left',
+        contain: true,
+        groupCells: columns > 1 ? columns : 1,
+        autoPlay: autoplay,
+        prevNextButtons: arrows,
+        pageDots: dots,
+        wrapAround: wrap,
+        fade: fade
+      };
+
+      if (fade) {
+        flickityOptions.groupCells = false;
+      }
+
+      $slider.flickity(flickityOptions);
+      $slider.addClass('is-initialized');
+    });
+  }
+
+  $(document).ready(function () {
+    initBwProductsSlider($(document));
   });
-});
+
+  jQuery(window).on('elementor/frontend/init', function () {
+    elementorFrontend.hooks.addAction('frontend/element_ready/bw_products_slide.default', initBwProductsSlider);
+  });
+
+  window.initBwProductsSlider = initBwProductsSlider;
+})(jQuery);


### PR DESCRIPTION
## Summary
- add an initBwProductsSlider helper that configures Flickity only once per scope based on data attributes
- hook the slider initialization into Elementor's frontend ready event so the widget renders inside the editor

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7a1e677888325823359d179ce235f