### PR TITLE
Fix BW Products Slide assets and initialization

### DIFF
--- a/assets/js/bw-products-slide.js
+++ b/assets/js/bw-products-slide.js
@@ -1,84 +1,41 @@
 (function ($) {
-  function parseBoolean(value) {
-    if (value === undefined || value === null) {
-      return false;
+    function initBwProductsSlider($scope) {
+        var $slider = $scope.find('.bw-products-slider');
+        if (!$slider.length) return;
+
+        // Evita doppia init
+        if ($slider.hasClass('is-initialized')) return;
+        $slider.addClass('is-initialized');
+
+        // Leggi data-*
+        var autoplay = $slider.data('autoplay') ? parseInt($slider.data('autoplay'), 10) : false;
+        var arrows   = ($slider.data('arrows') === true || $slider.data('arrows') === 'true');
+        var dots     = ($slider.data('dots') === true || $slider.data('dots') === 'true');
+        var wrap     = ($slider.data('wrap') === true || $slider.data('wrap') === 'true');
+        var fade     = ($slider.data('fade') === true || $slider.data('fade') === 'true');
+        var gap      = $slider.data('gap') ? parseInt($slider.data('gap'), 10) : 0;
+        var columns  = $slider.data('columns') ? parseInt($slider.data('columns'), 10) : 3;
+
+        // Colonne + gap via CSS inline (leggero)
+        $slider.find('.carousel-cell').css({
+            'width': (100 / columns) + '%',
+            'margin-right': gap + 'px'
+        });
+
+        // Init Flickity una sola volta
+        $slider.flickity({
+            cellAlign: 'left',
+            contain: true,
+            autoPlay: autoplay,
+            prevNextButtons: arrows,
+            pageDots: dots,
+            wrapAround: wrap,
+            fade: fade
+        });
     }
 
-    if (typeof value === 'string') {
-      value = value.toLowerCase();
-      return value === 'true' || value === '1' || value === 'yes';
-    }
-
-    return Boolean(value);
-  }
-
-  function initBwProductsSlider($scope) {
-    var $sliders = $scope.find('.bw-products-slider');
-
-    if (!$sliders.length) {
-      return;
-    }
-
-    $sliders.each(function () {
-      var $slider = $(this);
-
-      if ($slider.hasClass('is-initialized')) {
-        return;
-      }
-
-      $slider.addClass('is-initialized');
-
-      var columns = parseInt($slider.data('columns'), 10);
-      var gap = parseInt($slider.data('gap'), 10);
-
-      if (isNaN(columns) || columns < 1) {
-        columns = 1;
-      }
-
-      if ($slider.length) {
-        if (!isNaN(gap)) {
-          $slider[0].style.setProperty('--gap', gap + 'px');
-        }
-
-        $slider[0].style.setProperty('--columns', columns);
-      }
-
-      var autoplayAttr = $slider.data('autoplay');
-      var autoplay = false;
-
-      if (autoplayAttr !== undefined && autoplayAttr !== '' && autoplayAttr !== false) {
-        var autoplayValue = parseInt(autoplayAttr, 10);
-        autoplay = !isNaN(autoplayValue) && autoplayValue > 0 ? autoplayValue : false;
-      }
-
-      var fade = parseBoolean($slider.data('fade'));
-
-      var flickityOptions = {
-        cellAlign: 'left',
-        contain: true,
-        groupCells: columns > 1 ? columns : 1,
-        autoPlay: autoplay,
-        wrapAround: parseBoolean($slider.data('wrap')),
-        fade: fade,
-        prevNextButtons: parseBoolean($slider.data('arrows')),
-        pageDots: parseBoolean($slider.data('dots'))
-      };
-
-      if (fade) {
-        flickityOptions.groupCells = false;
-      }
-
-      $slider.flickity(flickityOptions);
+    // Hook Elementor: frontend + editor (solo quando il widget è pronto)
+    $(window).on('elementor/frontend/init', function () {
+        elementorFrontend.hooks.addAction('frontend/element_ready/bw_products_slide.default', initBwProductsSlider);
     });
-  }
-
-  $(function () {
-    initBwProductsSlider($(document));
-  });
-
-  jQuery(window).on('elementor/frontend/init', function () {
-    elementorFrontend.hooks.addAction('frontend/element_ready/bw_products_slide.default', initBwProductsSlider);
-  });
-
-  window.initBwProductsSlider = initBwProductsSlider;
 })(jQuery);

--- a/bw-main-elementor-widgets.php
+++ b/bw-main-elementor-widgets.php
@@ -15,45 +15,11 @@ require_once __DIR__ . '/includes/class-bw-widget-loader.php';
 
 // Registrazione eventuali asset globali
 function bw_widgets_register_assets() {
-    $plugin_dir_url  = plugin_dir_url( __FILE__ );
-    $plugin_dir_path = plugin_dir_path( __FILE__ );
+    wp_register_style( 'flickity-css', 'https://unpkg.com/flickity@2.3.0/dist/flickity.css', [], '2.3.0' );
+    wp_register_script( 'flickity-js', 'https://unpkg.com/flickity@2.3.0/dist/flickity.pkgd.min.js', [], '2.3.0', true );
 
-    // Flickity
-    wp_register_style(
-        'flickity-css',
-        'https://unpkg.com/flickity@2.3.0/dist/flickity.css',
-        [],
-        '2.3.0'
-    );
-
-    wp_register_script(
-        'flickity-js',
-        'https://unpkg.com/flickity@2.3.0/dist/flickity.pkgd.min.js',
-        [],
-        '2.3.0',
-        true
-    );
-
-    $style_path  = $plugin_dir_path . 'assets/css/bw-products-slide.css';
-    $style_ver   = file_exists( $style_path ) ? filemtime( $style_path ) : null;
-    $script_path = $plugin_dir_path . 'assets/js/bw-products-slide.js';
-    $script_ver  = file_exists( $script_path ) ? filemtime( $script_path ) : null;
-
-    // Widget assets
-    wp_register_style(
-        'bw-products-slide-style',
-        $plugin_dir_url . 'assets/css/bw-products-slide.css',
-        [],
-        $style_ver
-    );
-
-    wp_register_script(
-        'bw-products-slide-script',
-        $plugin_dir_url . 'assets/js/bw-products-slide.js',
-        [ 'jquery', 'flickity-js' ],
-        $script_ver,
-        true
-    );
+    wp_register_style( 'bw-products-slide-style', plugins_url( '/assets/css/bw-products-slide.css', __FILE__ ) );
+    wp_register_script( 'bw-products-slide-script', plugins_url( '/assets/js/bw-products-slide.js', __FILE__ ), [ 'jquery', 'flickity-js' ], '1.0', true );
 }
 add_action( 'wp_enqueue_scripts', 'bw_widgets_register_assets' );
 add_action( 'elementor/frontend/after_register_styles', 'bw_widgets_register_assets' );

--- a/includes/widgets/class-bw-products-slide-widget.php
+++ b/includes/widgets/class-bw-products-slide-widget.php
@@ -321,12 +321,11 @@ class Widget_Bw_Products_Slide extends Widget_Base {
             'class="bw-products-slider"',
             'data-columns="' . esc_attr( $columns ) . '"',
             'data-gap="' . esc_attr( $gap ) . '"',
-            'data-auto-play="' . esc_attr( $autoplay_enabled ? 'yes' : 'no' ) . '"',
-            'data-auto-play-speed="' . esc_attr( $autoplay_speed ) . '"',
-            'data-prev-next-buttons="' . esc_attr( $prev_next_buttons ? 'yes' : 'no' ) . '"',
-            'data-page-dots="' . esc_attr( $page_dots ? 'yes' : 'no' ) . '"',
-            'data-wrap-around="' . esc_attr( $wrap_around ? 'yes' : 'no' ) . '"',
-            'data-fade="' . esc_attr( $fade ? 'yes' : 'no' ) . '"',
+            'data-autoplay="' . esc_attr( $autoplay_enabled ? $autoplay_speed : 'false' ) . '"',
+            'data-arrows="' . esc_attr( $prev_next_buttons ? 'true' : 'false' ) . '"',
+            'data-dots="' . esc_attr( $page_dots ? 'true' : 'false' ) . '"',
+            'data-wrap="' . esc_attr( $wrap_around ? 'true' : 'false' ) . '"',
+            'data-fade="' . esc_attr( $fade ? 'true' : 'false' ) . '"',
             'style="' . esc_attr( $style_attr ) . '"',
         ];
 


### PR DESCRIPTION
## Summary
- register Flickity and widget assets with consistent handles for frontend and Elementor editor
- expose data attributes from the BW Products Slide widget to drive slider options
- replace the slider script with an editor-safe Flickity initializer

## Testing
- php -l bw-main-elementor-widgets.php
- php -l includes/widgets/class-bw-products-slide-widget.php

------
https://chatgpt.com/codex/tasks/task_e_68d7a458f35883259a15269a35465ddd