### PR TITLE
Fix product slider initialization timing

### DIFF
--- a/assets/js/bw-products-slide.js
+++ b/assets/js/bw-products-slide.js
@@ -38,10 +38,16 @@
             wrapAround: wrap,
             fade: fade
         });
+        if (typeof $slider.imagesLoaded === 'function') {
+            $slider.imagesLoaded(function () {
+                $slider.flickity('resize');
+                $slider.flickity('reloadCells');
+            });
+        }
         setTimeout(function () {
             $slider.flickity('resize');
             $slider.flickity('reloadCells');
-        }, 300);
+        }, 500);
         console.log('>>> Flickity inizializzato su', $slider);
     }
 


### PR DESCRIPTION
## Summary
- wait for slider images to load before forcing Flickity to recalculate layout
- add a delayed resize/reload to keep the slider stable in the Elementor editor

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7b4118e248325934c0cc6c201f39c