### PR TITLE
Simplify BW Products Slide widget for diagnostics

### DIFF
--- a/assets/css/bw-products-slide.css
+++ b/assets/css/bw-products-slide.css
@@ -1,31 +1,11 @@
-/* Fallback editor: prima dell'init usa una griglia leggibile */
-.bw-products-slider:not(.flickity-enabled) {
-  display: grid;
-  grid-template-columns: repeat(var(--columns, 3), minmax(0, 1fr));
-  gap: var(--gap, 20px);
+.bw-products-slider {
+  width: 100%;
 }
-
-/* Dopo l'init: Flickity gestisce il layout */
-.bw-products-slider.flickity-enabled {
-  display: block; /* lascia a Flickity il controllo del layout */
+.bw-products-slider .carousel-cell {
+  width: 100%;
 }
-
-/* Celle: reset margini quando siamo in fallback */
-.bw-products-slider:not(.flickity-enabled) .carousel-cell {
-  width: auto;
-  margin: 0;
-}
-
-/* Quando Flickity è attivo, lasciamo che posizioni lui: niente margini orizzontali esterni */
-.carousel-cell img {
+.bw-products-slider .carousel-cell img {
   display: block;
   width: 100%;
   height: auto;
-  object-fit: cover;
-}
-
-.caption {
-  margin-top: 10px;
-  text-align: center;
-  font-family: serif;
 }

--- a/assets/js/bw-products-slide.js
+++ b/assets/js/bw-products-slide.js
@@ -1,92 +1,21 @@
-(function ($) {
-  function boolData(v) { return v === true || v === 'true' || v === 1 || v === '1'; }
-
-  function initBwProductsSlider($scope) {
+(function($){
+  function initBwProductsSlider($scope){
     var $slider = $scope.find('.bw-products-slider');
-    if (!$slider.length) return;
+    if(!$slider.length) return;
+    if($slider.hasClass('f-initialized')) return;
+    $slider.addClass('f-initialized');
 
-    // evita doppia init
-    if ($slider.data('bw-init')) return;
-    $slider.data('bw-init', true);
-
-    // leggi data-*
-    var autoplay = $slider.data('autoplay') ? parseInt($slider.data('autoplay'), 10) : false;
-    var arrows   = boolData($slider.data('arrows'));
-    var dots     = boolData($slider.data('dots'));
-    var wrap     = boolData($slider.data('wrap'));
-    var fade     = boolData($slider.data('fade'));
-    var columns  = $slider.data('columns') ? parseInt($slider.data('columns'), 10) : 3;
-    var gap      = $slider.data('gap') ? parseInt($slider.data('gap'), 10) : 20;
-
-    // imposta larghezze cella per sicurezza (non fanno danno anche con Flickity)
-    $slider.find('.carousel-cell').css({ width: (100 / columns) + '%' });
-
-    function refreshSlider() {
-      $slider.flickity('resize').flickity('reloadCells');
-    }
-
-    function scheduleRefreshes() {
-      refreshSlider();
-      setTimeout(refreshSlider, 300);
-      setTimeout(refreshSlider, 1000);
-      setTimeout(refreshSlider, 2000);
-    }
-
-    // inizializza Flickity
     $slider.flickity({
       cellAlign: 'left',
       contain: true,
-      autoPlay: autoplay || false,
-      prevNextButtons: arrows,
-      pageDots: dots,
-      wrapAround: wrap,
-      fade: fade
+      autoPlay: 2000,
+      prevNextButtons: true,
+      pageDots: true,
+      wrapAround: true
     });
-
-    scheduleRefreshes();
-
-    // quando Flickity è pronto, ricalcola
-    $slider.on('ready.flickity', function () {
-      refreshSlider();
-    });
-
-    // dopo immagini caricate (richiede imagesLoaded che è nel pkgd)
-    $slider.imagesLoaded(function () {
-      scheduleRefreshes();
-    });
-
-    // su window load e resize
-    $(window).on('load resize', function () {
-      refreshSlider();
-    });
-
-    // Fix per editor: rinfresca quando Elementor aggiorna pannelli / DOM
-    if (window.elementorFrontend && elementorFrontend.isEditMode()) {
-      // quando il widget viene (ri)renderizzato
-      setTimeout(refreshSlider, 300);
-      // quando si cambia pannello o controllo
-      elementor.channels.editor && elementor.channels.editor.on('change', function(){
-        refreshSlider();
-      });
-      // osserva cambi dimensioni del contenitore
-      var ro = new ResizeObserver(function(){ refreshSlider(); });
-      ro.observe($slider.get(0));
-
-      var editRefreshDuration = 10000;
-      var editRefreshInterval = 2000;
-      var elapsed = 0;
-      var intervalId = setInterval(function () {
-        elapsed += editRefreshInterval;
-        refreshSlider();
-        if (elapsed >= editRefreshDuration) {
-          clearInterval(intervalId);
-        }
-      }, editRefreshInterval);
-    }
   }
 
-  // hook Elementor (frontend + editor)
-  $(window).on('elementor/frontend/init', function () {
+  $(window).on('elementor/frontend/init', function(){
     elementorFrontend.hooks.addAction('frontend/element_ready/bw_products_slide.default', initBwProductsSlider);
   });
 })(jQuery);

--- a/includes/widgets/class-bw-products-slide-widget.php
+++ b/includes/widgets/class-bw-products-slide-widget.php
@@ -249,129 +249,13 @@ class Widget_Bw_Products_Slide extends Widget_Base {
     }
 
     protected function render() {
-        $settings = $this->get_settings_for_display();
-
-        $args = [
-            'posts_per_page' => -1,
-        ];
-
-        $post_type = ! empty( $settings['post_type'] ) ? $settings['post_type'] : 'post';
-
-        if ( 'all' === $post_type ) {
-            $args['post_type'] = get_post_types( [ 'public' => true ] );
-            $args['orderby']   = 'date';
-            $args['order']     = 'DESC';
-        } else {
-            $args['post_type'] = $post_type;
-        }
-
-        if ( $settings['category'] ) {
-            $args['category_name'] = $settings['category'];
-        }
-
-        if ( $settings['include_ids'] ) {
-            $ids = array_filter( array_map( 'intval', array_map( 'trim', explode( ',', $settings['include_ids'] ) ) ) );
-
-            if ( ! empty( $ids ) ) {
-                $args['post__in'] = $ids;
-            }
-        }
-
-        $query = new \WP_Query( $args );
-
-        if ( ! $query->have_posts() ) {
-            wp_reset_postdata();
-            return;
-        }
-
-        $columns_setting = isset( $settings['columns'] ) ? $settings['columns'] : 3;
-        if ( is_array( $columns_setting ) ) {
-            if ( isset( $columns_setting['size'] ) ) {
-                $columns = (int) $columns_setting['size'];
-            } elseif ( isset( $columns_setting['value'] ) ) {
-                $columns = (int) $columns_setting['value'];
-            } else {
-                $columns = (int) reset( $columns_setting );
-            }
-        } else {
-            $columns = (int) $columns_setting;
-        }
-        $columns = max( 2, min( 6, $columns ) );
-
-        $gap_setting = isset( $settings['gap'] ) ? $settings['gap'] : 20;
-        if ( is_array( $gap_setting ) ) {
-            if ( isset( $gap_setting['size'] ) ) {
-                $gap = (int) $gap_setting['size'];
-            } elseif ( isset( $gap_setting['value'] ) ) {
-                $gap = (int) $gap_setting['value'];
-            } else {
-                $gap = (int) reset( $gap_setting );
-            }
-        } else {
-            $gap = (int) $gap_setting;
-        }
-        $gap = max( 0, $gap );
-
-        $image_height = isset( $settings['image_height'] ) ? (int) $settings['image_height'] : 0;
-
-        $autoplay_enabled = isset( $settings['autoplay'] ) && 'yes' === $settings['autoplay'];
-        $autoplay_speed   = isset( $settings['autoplay_speed'] ) ? (int) $settings['autoplay_speed'] : 3000;
-        $autoplay_speed   = $autoplay_speed > 0 ? $autoplay_speed : 3000;
-
-        $prev_next_buttons = isset( $settings['prev_next_buttons'] ) && 'yes' === $settings['prev_next_buttons'];
-        $page_dots         = isset( $settings['page_dots'] ) && 'yes' === $settings['page_dots'];
-        $wrap_around       = isset( $settings['wrap_around'] ) && 'yes' === $settings['wrap_around'];
-        $fade              = isset( $settings['fade'] ) && 'yes' === $settings['fade'];
-
-        $show_title    = isset( $settings['show_title'] ) && 'yes' === $settings['show_title'];
-        $show_subtitle = isset( $settings['show_subtitle'] ) && 'yes' === $settings['show_subtitle'];
-        $show_price    = isset( $settings['show_price'] ) && 'yes' === $settings['show_price'];
-
-        $style_attr = sprintf(
-            '--columns: %1$d; --gap: %2$dpx; --image-height: %3$s;',
-            $columns,
-            $gap,
-            $image_height > 0 ? $image_height . 'px' : 'auto'
-        );
-
-        $slider_attributes = [
-            'class="bw-products-slider"',
-            'style="' . esc_attr( $style_attr ) . '"',
-            'data-columns="' . esc_attr( $columns ) . '"',
-            'data-gap="' . esc_attr( $gap ) . '"',
-            'data-autoplay="' . esc_attr( $autoplay_enabled ? $autoplay_speed : 0 ) . '"',
-            'data-arrows="' . esc_attr( $prev_next_buttons ? 'true' : 'false' ) . '"',
-            'data-dots="' . esc_attr( $page_dots ? 'true' : 'false' ) . '"',
-            'data-wrap="' . esc_attr( $wrap_around ? 'true' : 'false' ) . '"',
-            'data-fade="' . esc_attr( $fade ? 'true' : 'false' ) . '"',
-        ];
-
-        echo '<div ' . implode( ' ', $slider_attributes ) . '>';
-
-        while ( $query->have_posts() ) : $query->the_post();
+        echo '<div class="bw-products-slider">';
+        for ( $i = 1; $i <= 5; $i++ ) {
             echo '<div class="carousel-cell">';
-                if ( has_post_thumbnail() ) {
-                    echo '<img src="' . esc_url( get_the_post_thumbnail_url( get_the_ID(), 'medium' ) ) . '" alt="' . esc_attr( get_the_title() ) . '">';
-                }
-                echo '<div class="caption">';
-                    if ( $show_title ) {
-                        echo '<h4>' . esc_html( get_the_title() ) . '</h4>';
-                    }
-                    if ( $show_subtitle ) {
-                        echo '<p>' . esc_html( get_the_excerpt() ) . '</p>';
-                    }
-                    if ( $show_price && function_exists( 'wc_get_product' ) ) {
-                        $product = wc_get_product( get_the_ID() );
-                        if ( $product ) {
-                            echo '<span class="price">' . wp_kses_post( $product->get_price_html() ) . '</span>';
-                        }
-                    }
-                echo '</div>';
+            echo '<img src="https://via.placeholder.com/400x300?text=Slide+' . $i . '" alt="Slide ' . $i . '">';
             echo '</div>';
-        endwhile;
-
+        }
         echo '</div>';
-        wp_reset_postdata();
     }
 
     private function get_post_type_options() {


### PR DESCRIPTION
## Summary
- replace the widget render method with a static five-slide placeholder output for easier troubleshooting
- simplify the slider stylesheet to minimal width and image rules
- streamline the JavaScript initializer to a basic Flickity setup with fixed demo settings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7c40b96108325b2c6fe15b0589a41