### PR TITLE
Update BW Products Slide placeholder image and styling

### DIFF
--- a/assets/css/bw-products-slide.css
+++ b/assets/css/bw-products-slide.css
@@ -1,5 +1,6 @@
 .bw-products-slider {
   width: 100%;
+  overflow: hidden;
 }
 .bw-products-slider .carousel-cell {
   width: 100%;
@@ -8,4 +9,6 @@
   display: block;
   width: 100%;
   height: auto;
+  min-height: 200px;
+  object-fit: cover;
 }

--- a/includes/widgets/class-bw-products-slide-widget.php
+++ b/includes/widgets/class-bw-products-slide-widget.php
@@ -249,10 +249,14 @@ class Widget_Bw_Products_Slide extends Widget_Base {
     }
 
     protected function render() {
+        $src = esc_url( includes_url( 'images/uploader.png' ) );
+
         echo '<div class="bw-products-slider">';
         for ( $i = 1; $i <= 5; $i++ ) {
+            $alt = sprintf( 'Slide %d', $i );
+
             echo '<div class="carousel-cell">';
-            echo '<img src="https://via.placeholder.com/400x300?text=Slide+' . $i . '" alt="Slide ' . $i . '">';
+            echo '<img src="' . $src . '" alt="' . esc_attr( $alt ) . '">';
             echo '</div>';
         }
         echo '</div>';


### PR DESCRIPTION
## Summary
- replace external placeholder URLs in the BW Products Slide widget with the bundled WordPress uploader demo image
- adjust slider image styles to ensure consistent sizing and visibility in both the Elementor editor and frontend

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7d432c2a88325a401cf472d24a8ed