### PR TITLE
Ensure Flickity loads inside Elementor preview

### DIFF
--- a/assets/js/bw-products-slide.js
+++ b/assets/js/bw-products-slide.js
@@ -1,4 +1,5 @@
 (function($){
+  console.log("✅ Init BW Products Slider JS caricato");
   function waitForImages($wrap){
     return new Promise(function(resolve){
       var $imgs = $wrap.find('img'); if(!$imgs.length) return resolve();

--- a/bw-main-elementor-widgets.php
+++ b/bw-main-elementor-widgets.php
@@ -40,8 +40,10 @@ add_action( 'elementor/frontend/after_register_styles', 'bw_widgets_register_ass
 
 add_action( 'elementor/preview/enqueue_scripts', function() {
     wp_enqueue_script( 'flickity-js' );
+    wp_enqueue_style( 'flickity-css' );
     wp_enqueue_script( 'bw-products-slide-script' );
-    wp_add_inline_script( 'bw-products-slide-script', 'console.log("✅ BW Products JS ENQUEUED in preview iframe");' );
+    wp_enqueue_style( 'bw-products-slide-style' );
+    wp_add_inline_script( 'flickity-js', 'console.log("✅ Flickity caricato anche in editor Elementor");' );
 } );
 
 add_action( 'elementor/preview/enqueue_styles', function() {


### PR DESCRIPTION
## Summary
- ensure Flickity assets are enqueued for Elementor's preview iframe with an inline log confirming the load
- log the BW Products slider script initialization so editors can confirm the widget script runs in Elementor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f7129adc83258c17cd64c01d886a