### PR TITLE
Fix Flickity initialization for BW products slider

### DIFF
--- a/assets/js/bw-products-slide.js
+++ b/assets/js/bw-products-slide.js
@@ -1,56 +1,29 @@
 (function($){
   console.log("✅ Init BW Products Slider JS caricato");
-  function waitForImages($wrap){
-    return new Promise(function(resolve){
-      var $imgs = $wrap.find('img'); if(!$imgs.length) return resolve();
-      var pending = $imgs.length;
-      $imgs.each(function(){
-        if (this.complete) { if(--pending===0) resolve(); }
-        else $(this).one('load error', function(){ if(--pending===0) resolve(); });
-      });
-    });
-  }
 
-  function refresh($s){ $s.flickity('resize').flickity('reloadCells'); }
+  jQuery(window).on('elementor/frontend/init', function() {
+    var editMode = Boolean(elementorFrontend.isEditMode());
+    console.log("BW Products JS LOADED — editMode:", editMode);
 
-  function initBwProductsSlider($scope){
-    var $s = $scope.find('.bw-products-slider'); if(!$s.length) return;
-    if($s.data('bw-init')) { refresh($s); return; }
-    $s.data('bw-init', true);
+    elementorFrontend.hooks.addAction(
+      'frontend/element_ready/bw_products_slide.default',
+      initBwProductsSlider
+    );
+  });
 
-    // inizializza dopo primo paint
-    requestAnimationFrame(function(){
-      $s.flickity({
+  function initBwProductsSlider($scope) {
+    console.log("👉 initBwProductsSlider called", $scope);
+
+    var $carousel = $scope.find('.bw-products-slider');
+    if ($carousel.length) {
+      $carousel.flickity({
         cellAlign: 'left',
         contain: true,
-        autoPlay: 2500,
-        prevNextButtons: true,
         pageDots: true,
+        prevNextButtons: true,
         wrapAround: true,
-        draggable: '>1',
-        watchCSS: false
+        groupCells: true
       });
-
-      // rinfreschi scaglionati
-      refresh($s);
-      setTimeout(function(){ refresh($s); }, 300);
-      setTimeout(function(){ refresh($s); }, 1000);
-
-      // dopo caricamento immagini (senza imagesLoaded)
-      waitForImages($s).then(function(){ refresh($s); });
-
-      // editor: osserva ridimensionamenti del widget/iframe
-      if (window.elementorFrontend && elementorFrontend.isEditMode() && 'ResizeObserver' in window) {
-        var ro = new ResizeObserver(function(){ refresh($s); });
-        ro.observe($s.get(0));
-        // ping iniziali per stabilizzare
-        var i = setInterval(function(){ refresh($s); }, 1500);
-        setTimeout(function(){ clearInterval(i); }, 7000);
-      }
-    });
+    }
   }
-
-  $(window).on('elementor/frontend/init', function(){
-    elementorFrontend.hooks.addAction('frontend/element_ready/bw_products_slide.default', initBwProductsSlider);
-  });
 })(jQuery);


### PR DESCRIPTION
## Summary
- add Elementor frontend init listener that logs edit mode state
- simplify bw products Flickity initialization to run immediately in editor and frontend

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7fa00a7a88325a5fe4a69437538be