### PR TITLE
Fix Flickity slider initialization inside Elementor editor

### DIFF
--- a/assets/js/bw-products-slide.js
+++ b/assets/js/bw-products-slide.js
@@ -1,26 +1,19 @@
-(function($) {
-  jQuery(window).on('elementor/frontend/init', function() {
-    console.log('✅ BW Products Slider JS inizializzato');
+jQuery(window).on('elementor/frontend/init', function () {
+  elementorFrontend.hooks.addAction(
+    'frontend/element_ready/bw_products_slide.default',
+    function ($scope) {
+      var $carousel = $scope.find('.bw-products-slider');
 
-    elementorFrontend.hooks.addAction(
-      'frontend/element_ready/bw_products_slide.default',
-      initBwProductsSlider
-    );
-  });
-
-  function initBwProductsSlider($scope) {
-    console.log('👉 initBwProductsSlider chiamato');
-
-    var $carousel = $scope.find('.bw-products-slider');
-    if ($carousel.length && !$carousel.data('flickity')) {
-      $carousel.flickity({
-        cellAlign: 'left',
-        contain: true,
-        pageDots: true,
-        prevNextButtons: true,
-        wrapAround: true,
-        groupCells: true
-      });
+      if ($carousel.length && !$carousel.data('flickity')) {
+        $carousel.flickity({
+          cellAlign: 'left',
+          contain: true,
+          pageDots: true,
+          prevNextButtons: true,
+          wrapAround: true,
+          groupCells: true
+        });
+      }
     }
-  }
-})(jQuery);
+  );
+});

--- a/bw-main-elementor-widgets.php
+++ b/bw-main-elementor-widgets.php
@@ -54,6 +54,16 @@ add_action( 'elementor/frontend/after_enqueue_styles', static function() {
     wp_enqueue_style( 'bw-products-slide-style' );
 } );
 
+add_action( 'elementor/editor/after_enqueue_scripts', static function() {
+    wp_enqueue_script( 'flickity-js' );
+    wp_enqueue_script( 'bw-products-slide-script' );
+} );
+
+add_action( 'elementor/editor/after_enqueue_styles', static function() {
+    wp_enqueue_style( 'flickity-css' );
+    wp_enqueue_style( 'bw-products-slide-style' );
+} );
+
 // Aggiungi categoria personalizzata "Black Work"
 add_action( 'elementor/elements/categories_registered', static function( $elements_manager ) {
     if ( ! method_exists( $elements_manager, 'add_category' ) ) {

--- a/includes/widgets/class-bw-products-slide-widget.php
+++ b/includes/widgets/class-bw-products-slide-widget.php
@@ -249,8 +249,10 @@ class Widget_Bw_Products_Slide extends Widget_Base {
     }
 
     protected function render() {
+        $carousel_id = 'bw-products-slider-' . $this->get_id();
+
         ?>
-        <div class="bw-products-slider">
+        <div id="<?php echo esc_attr( $carousel_id ); ?>" class="bw-products-slider">
             <?php for ( $i = 1; $i <= 5; $i++ ) : ?>
                 <div class="carousel-cell">
                     <div class="cell-media">Slide <?php echo $i; ?></div>
@@ -259,10 +261,9 @@ class Widget_Bw_Products_Slide extends Widget_Base {
         </div>
         <?php if ( \Elementor\Plugin::$instance->editor->is_edit_mode() ) : ?>
             <script>
-            jQuery(document).ready(function($) {
-                var $carousel = $('.bw-products-slider');
+            jQuery(function($) {
+                var $carousel = $('#<?php echo esc_js( $carousel_id ); ?>');
                 if ($carousel.length && !$carousel.data('flickity')) {
-                    console.log("🎯 Init Flickity from inline script (editor mode)");
                     $carousel.flickity({
                         cellAlign: 'left',
                         contain: true,


### PR DESCRIPTION
## Summary
- ensure the BW Products Slide widget hooks into Elementor's frontend init to initialise Flickity only when needed
- add an editor-mode fallback script tied to each widget instance so the carousel works inside the Elementor editor
- enqueue Flickity assets for both the frontend and Elementor editor contexts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d90501d6dc8325a83035841672b7e5