### PR TITLE
Fix Flickity initialization for BW Products Slide

### DIFF
--- a/assets/js/bw-products-slide.js
+++ b/assets/js/bw-products-slide.js
@@ -3,8 +3,13 @@ jQuery(window).on('elementor/frontend/init', function () {
     'frontend/element_ready/bw-products-slide.default',
     function ($scope, $) {
       var $carousel = $scope.find('.bw-products-slider');
-      if ($carousel.length && !$carousel.data('flickity')) {
-        $carousel.flickity({
+      var carouselElement = $carousel.length ? $carousel.get(0) : null;
+      if (
+        carouselElement &&
+        !$carousel.data('flickity') &&
+        !(carouselElement.flickity && carouselElement.flickity.isInitActivated)
+      ) {
+        var flkty = new Flickity(carouselElement, {
           cellAlign: 'left',
           contain: true,
           wrapAround: true,
@@ -12,6 +17,9 @@ jQuery(window).on('elementor/frontend/init', function () {
           prevNextButtons: true,
           autoPlay: 3000
         });
+        $carousel.data('flickity', flkty);
+        flkty.resize();
+        window.dispatchEvent(new Event('resize'));
       }
     }
   );


### PR DESCRIPTION
## Summary
- prevent duplicate Flickity initialization for the BW Products Slide widget
- instantiate Flickity directly, force immediate resize, and dispatch a window resize event for reliable first-load rendering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d91021575483259e96f5ce87be4ec2