### PR TITLE
Fix Flickity slider initialization in Elementor editor

### DIFF
--- a/assets/js/bw-products-slide.js
+++ b/assets/js/bw-products-slide.js
@@ -18,6 +18,13 @@ jQuery(window).on('elementor/frontend/init', function () {
           prevNextButtons: true,
           autoPlay: 3000
         });
+        if (elementorFrontend.isEditMode()) {
+          flkty.on('ready', function () {
+            flkty.reloadCells();
+            flkty.resize();
+            window.dispatchEvent(new Event('resize'));
+          });
+        }
         $carousel.data('flickity', flkty);
         flkty.resize();
         window.dispatchEvent(new Event('resize'));


### PR DESCRIPTION
## Summary
- add a Flickity ready listener when running in Elementor editor to reload and resize cells on load

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9235cedcc8325b3a28008321dfa9b