### PR TITLE
Improve Flickity initialization in Elementor editor

### DIFF
--- a/assets/js/bw-products-slide.js
+++ b/assets/js/bw-products-slide.js
@@ -19,11 +19,45 @@ jQuery(window).on('elementor/frontend/init', function () {
           autoPlay: 3000
         });
         if (elementorFrontend.isEditMode()) {
+          console.log('Flickity init in editor', carouselElement);
           flkty.on('ready', function () {
+            console.log('Flickity ready in editor, triggering reload and resize');
             flkty.reloadCells();
             flkty.resize();
             window.dispatchEvent(new Event('resize'));
+            setTimeout(function () {
+              console.log('Flickity delayed resize after ready');
+              flkty.resize();
+              window.dispatchEvent(new Event('resize'));
+            }, 200);
           });
+
+          if (!$carousel.data('bwFlickityEditorEventsBound')) {
+            var editorChannel = elementor && elementor.channels && elementor.channels.editor;
+            if (editorChannel && editorChannel.on) {
+              editorChannel.on('panel:open', function () {
+                console.log('Flickity resize after panel open');
+                flkty.reloadCells();
+                flkty.resize();
+              });
+              editorChannel.on('panel:close', function () {
+                console.log('Flickity resize after panel close');
+                flkty.reloadCells();
+                flkty.resize();
+              });
+            }
+
+            elementorFrontend.hooks.addAction(
+              'document/responsive/after_set_breakpoint',
+              function () {
+                console.log('Flickity resize after breakpoint change');
+                flkty.resize();
+                window.dispatchEvent(new Event('resize'));
+              }
+            );
+
+            $carousel.data('bwFlickityEditorEventsBound', true);
+          }
         }
         $carousel.data('flickity', flkty);
         flkty.resize();


### PR DESCRIPTION
## Summary
- update the BW Products slider Flickity init to always use imagesLoaded and guard double initialization
- add Elementor editor-specific ready, panel, and breakpoint hooks to reload and resize the carousel reliably
- include debug console logs to trace editor lifecycle adjustments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d92628552c8325bc2a9dc56ee1d559