### PR TITLE
Restore dynamic data and Flickity integration for BW Products Slide

### DIFF
--- a/assets/css/bw-products-slide.css
+++ b/assets/css/bw-products-slide.css
@@ -1,8 +1,22 @@
-.bw-products-slider { width: 100%; }
-.bw-products-slider .carousel-cell { width: 100%; }
+.bw-products-slider {
+  width: 100%;
+  --bw-columns: 1;
+  --bw-gap: 20px;
+  --bw-image-height: 280px;
+}
+
+.bw-products-slider .carousel-cell {
+  width: calc((100% - (var(--bw-columns) - 1) * var(--bw-gap)) / var(--bw-columns));
+  margin-right: var(--bw-gap);
+}
+
+.bw-products-slider .carousel-cell:last-child {
+  margin-right: 0;
+}
+
 .bw-products-slider .cell-media {
   width: 100%;
-  height: 280px;               /* test: evita altezza 0 */
+  height: var(--bw-image-height);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -10,10 +24,14 @@
   color: #555;
   font: 600 20px/1.2 system-ui, sans-serif;
 }
+
 .bw-products-slider .carousel-cell img {
   display: block;
   width: 100%;
-  height: 280px;
+  height: var(--bw-image-height);
   object-fit: cover;
 }
-.bw-products-slider.flickity-enabled { overflow: hidden; }
+
+.bw-products-slider.flickity-enabled {
+  overflow: hidden;
+}

--- a/assets/js/bw-products-slide.js
+++ b/assets/js/bw-products-slide.js
@@ -1,68 +1,100 @@
-jQuery(window).on('elementor/frontend/init', function () {
-  elementorFrontend.hooks.addAction(
-    'frontend/element_ready/bw-products-slide.default',
-    function ($scope, $) {
-      var $carousel = $scope.find('.bw-products-slider');
-      var carouselElement = $carousel.length ? $carousel.get(0) : null;
-      if (
-        carouselElement &&
-        !$carousel.data('flickity') &&
-        !(carouselElement.flickity && carouselElement.flickity.isInitActivated)
-      ) {
-        var flkty = new Flickity(carouselElement, {
-          cellAlign: 'left',
-          contain: true,
-          imagesLoaded: true,
-          wrapAround: true,
-          pageDots: true,
-          prevNextButtons: true,
-          autoPlay: 3000
-        });
-        if (elementorFrontend.isEditMode()) {
-          console.log('Flickity init in editor', carouselElement);
-          flkty.on('ready', function () {
-            console.log('Flickity ready in editor, triggering reload and resize');
-            flkty.reloadCells();
-            flkty.resize();
-            window.dispatchEvent(new Event('resize'));
-            setTimeout(function () {
-              console.log('Flickity delayed resize after ready');
-              flkty.resize();
-              window.dispatchEvent(new Event('resize'));
-            }, 200);
-          });
+(function ($) {
+  var initProductsSlider = function ($scope) {
+    var $carousel = $scope.find('.bw-products-slider');
+    if (!$carousel.length) {
+      return;
+    }
 
-          if (!$carousel.data('bwFlickityEditorEventsBound')) {
-            var editorChannel = elementor && elementor.channels && elementor.channels.editor;
-            if (editorChannel && editorChannel.on) {
-              editorChannel.on('panel:open', function () {
-                console.log('Flickity resize after panel open');
-                flkty.reloadCells();
-                flkty.resize();
-              });
-              editorChannel.on('panel:close', function () {
-                console.log('Flickity resize after panel close');
-                flkty.reloadCells();
-                flkty.resize();
-              });
-            }
+    var carouselElement = $carousel.get(0);
+    if (!carouselElement) {
+      return;
+    }
 
-            elementorFrontend.hooks.addAction(
-              'document/responsive/after_set_breakpoint',
-              function () {
-                console.log('Flickity resize after breakpoint change');
-                flkty.resize();
-                window.dispatchEvent(new Event('resize'));
-              }
-            );
+    var existingInstance = Flickity.data(carouselElement);
+    if (existingInstance) {
+      existingInstance.reloadCells();
+      existingInstance.resize();
+      window.dispatchEvent(new Event('resize'));
+      return;
+    }
 
-            $carousel.data('bwFlickityEditorEventsBound', true);
-          }
+    var parseBool = function (value, defaultValue) {
+      if (typeof value === 'undefined') {
+        return defaultValue;
+      }
+      if (typeof value === 'string') {
+        value = value.toLowerCase();
+        if (value === 'false' || value === '0' || value === 'no') {
+          return false;
         }
-        $carousel.data('flickity', flkty);
+        if (value === 'true' || value === '1' || value === 'yes') {
+          return true;
+        }
+      }
+      return Boolean(value);
+    };
+
+    var autoplaySetting = parseInt($carousel.data('autoplay'), 10);
+    var autoplayOption = 3000;
+    if (!isNaN(autoplaySetting)) {
+      autoplayOption = autoplaySetting > 0 ? autoplaySetting : false;
+    }
+
+    var options = {
+      imagesLoaded: true,
+      cellAlign: 'left',
+      contain: true,
+      wrapAround: parseBool($carousel.data('wrapAround'), true),
+      pageDots: parseBool($carousel.data('pageDots'), true),
+      prevNextButtons: parseBool($carousel.data('prevNextButtons'), true),
+      autoPlay: autoplayOption,
+    };
+
+    if ($carousel.data('fade') === 'yes') {
+      options.fade = true;
+    }
+
+    var flkty = new Flickity(carouselElement, options);
+    flkty.reloadCells();
+    flkty.resize();
+    window.dispatchEvent(new Event('resize'));
+
+    var handleResize = function () {
+      flkty.resize();
+    };
+
+    if (elementorFrontend.isEditMode()) {
+      var triggerFullRefresh = function () {
+        flkty.reloadCells();
         flkty.resize();
         window.dispatchEvent(new Event('resize'));
+      };
+
+      flkty.on('ready', triggerFullRefresh);
+
+      if (!$carousel.data('bwFlickityEditorEventsBound')) {
+        var editorChannel = elementor && elementor.channels && elementor.channels.editor;
+        if (editorChannel && editorChannel.on) {
+          editorChannel.on('panel:open', handleResize);
+          editorChannel.on('panel:close', handleResize);
+        }
+
+        elementorFrontend.hooks.addAction(
+          'document/responsive/after_set_breakpoint',
+          handleResize
+        );
+
+        $carousel.data('bwFlickityEditorEventsBound', true);
       }
     }
-  );
-});
+  };
+
+  jQuery(window).on('elementor/frontend/init', function () {
+    elementorFrontend.hooks.addAction(
+      'frontend/element_ready/bw-products-slide.default',
+      function ($scope) {
+        initProductsSlider($scope);
+      }
+    );
+  });
+})(jQuery);


### PR DESCRIPTION
## Summary
- rebuild the BW Products Slide markup to pull featured images, titles, excerpts, links, and price metadata while exposing slider options via data attributes
- initialize Flickity through the Elementor frontend hook with edit-mode safeguards, reloads, and responsive listeners to avoid double instantiation
- adjust slider CSS to honour column, gap, and image height settings using CSS custom properties for consistent layouts

## Testing
- php -l includes/widgets/class-bw-products-slide-widget.php

------
https://chatgpt.com/codex/tasks/task_e_68d927621d888325a0e466ce05e350b8