### PR TITLE
Guard Elementor editor channel before binding panel listeners

### DIFF
--- a/assets/js/bw-products-slide.js
+++ b/assets/js/bw-products-slide.js
@@ -74,7 +74,9 @@
       flkty.on('ready', triggerFullRefresh);
 
       if (!$carousel.data('bwFlickityEditorEventsBound')) {
-        var editorChannel = elementor && elementor.channels && elementor.channels.editor;
+        var editorChannel = typeof elementor !== 'undefined' && elementor.channels
+          ? elementor.channels.editor
+          : null;
         if (editorChannel && editorChannel.on) {
           editorChannel.on('panel:open', handleResize);
           editorChannel.on('panel:close', handleResize);


### PR DESCRIPTION
## Summary
- Guard access to the Elementor editor channel when registering editor-specific listeners.
- Ensure panel open/close handlers are only bound when the editor channel is present.

## Testing
- Not run (not requested).

------
https://chatgpt.com/codex/tasks/task_e_68dbd600c39083259d3cef1b6c70d26b