### PR TITLE
Reset Flickity instance before reinit

### DIFF
--- a/assets/js/bw-products-slide.js
+++ b/assets/js/bw-products-slide.js
@@ -12,10 +12,49 @@
 
     var existingInstance = Flickity.data(carouselElement);
     if (existingInstance) {
-      existingInstance.reloadCells();
-      existingInstance.resize();
-      window.dispatchEvent(new Event('resize'));
-      return;
+      var existingEditorEvents = $carousel.data('bwFlickityEditorEvents');
+
+      if (existingEditorEvents) {
+        if (
+          existingEditorEvents.editorChannel &&
+          typeof existingEditorEvents.editorChannel.off === 'function'
+        ) {
+          existingEditorEvents.editorChannel.off(
+            'panel:open',
+            existingEditorEvents.handleResize
+          );
+          existingEditorEvents.editorChannel.off(
+            'panel:close',
+            existingEditorEvents.handleResize
+          );
+        }
+
+        if (
+          typeof elementorFrontend !== 'undefined' &&
+          elementorFrontend.hooks &&
+          typeof elementorFrontend.hooks.removeAction === 'function'
+        ) {
+          elementorFrontend.hooks.removeAction(
+            'document/responsive/after_set_breakpoint',
+            existingEditorEvents.handleResize
+          );
+        }
+
+        if (
+          existingEditorEvents.flickityInstance &&
+          typeof existingEditorEvents.flickityInstance.off === 'function'
+        ) {
+          existingEditorEvents.flickityInstance.off(
+            'ready',
+            existingEditorEvents.triggerFullRefresh
+          );
+        }
+      }
+
+      existingInstance.destroy();
+
+      $carousel.removeData('bwFlickityEditorEvents');
+      $carousel.removeData('bwFlickityEditorEventsBound');
     }
 
     var parseBool = function (value, defaultValue) {
@@ -88,6 +127,12 @@
         );
 
         $carousel.data('bwFlickityEditorEventsBound', true);
+        $carousel.data('bwFlickityEditorEvents', {
+          handleResize: handleResize,
+          triggerFullRefresh: triggerFullRefresh,
+          editorChannel: editorChannel,
+          flickityInstance: flkty,
+        });
       }
     }
   };


### PR DESCRIPTION
## Summary
- destroy any existing Flickity instance before rebuilding the products slider with the latest dataset attributes
- rebind Elementor editor resize hooks to the freshly instantiated slider so preview updates immediately when settings change

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbdb68201483258a9667f3c2232b90