### PR TITLE
Add typography tab and layout spacing controls to BW Slick Slider

### DIFF
--- a/assets/css/bw-slick-slider.css
+++ b/assets/css/bw-slick-slider.css
@@ -134,7 +134,8 @@
   gap: 12px;
 }
 
-.bw-slick-slider .bw-slick-item__title {
+.bw-slick-slider .bw-slick-item__title,
+.bw-slick-slider .bw-slick-title {
   margin: 0;
   font-size: 1.125rem;
   line-height: 1.3;
@@ -150,17 +151,20 @@
   text-decoration: underline;
 }
 
-.bw-slick-slider .bw-slick-item__excerpt {
+.bw-slick-slider .bw-slick-item__excerpt,
+.bw-slick-slider .bw-slick-description {
   color: #4b4b4b;
   font-size: 0.95rem;
   line-height: 1.55;
 }
 
-.bw-slick-slider .bw-slick-item__excerpt p {
+.bw-slick-slider .bw-slick-item__excerpt p,
+.bw-slick-slider .bw-slick-description p {
   margin: 0;
 }
 
-.bw-slick-slider .bw-slick-item__price {
+.bw-slick-slider .bw-slick-item__price,
+.bw-slick-slider .bw-slick-price {
   display: flex;
   flex-wrap: wrap;
   align-items: center;

--- a/includes/widgets/class-bw-slick-slider-widget.php
+++ b/includes/widgets/class-bw-slick-slider-widget.php
@@ -1,5 +1,6 @@
 <?php
 use Elementor\Controls_Manager;
+use Elementor\Group_Control_Typography;
 use Elementor\Repeater;
 use Elementor\Widget_Base;
 
@@ -99,6 +100,157 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
                 'px' => [ 'min' => 0, 'max' => 80, 'step' => 1 ],
             ],
             'default' => [ 'size' => 24, 'unit' => 'px' ],
+        ] );
+
+        $this->add_responsive_control( 'side_padding', [
+            'label' => __( 'Side Padding', 'bw-elementor-widgets' ),
+            'type'  => Controls_Manager::DIMENSIONS,
+            'allowed_dimensions' => [ 'left', 'right' ],
+            'size_units' => [ 'px', '%' ],
+            'range' => [
+                'px' => [ 'min' => 0, 'max' => 200, 'step' => 1 ],
+                '%'  => [ 'min' => 0, 'max' => 30, 'step' => 1 ],
+            ],
+            'selectors' => [
+                '{{WRAPPER}} .bw-slick-slider' => 'padding-left: {{LEFT}}{{UNIT}}; padding-right: {{RIGHT}}{{UNIT}};',
+            ],
+        ] );
+
+        $this->add_responsive_control( 'top_spacing', [
+            'label' => __( 'Top Spacing', 'bw-elementor-widgets' ),
+            'type'  => Controls_Manager::SLIDER,
+            'size_units' => [ 'px', '%' ],
+            'range' => [
+                'px' => [ 'min' => 0, 'max' => 200, 'step' => 1 ],
+                '%'  => [ 'min' => 0, 'max' => 30, 'step' => 1 ],
+            ],
+            'selectors' => [
+                '{{WRAPPER}} .bw-slick-slider' => 'padding-top: {{SIZE}}{{UNIT}};',
+            ],
+        ] );
+
+        $this->add_responsive_control( 'bottom_spacing', [
+            'label' => __( 'Bottom Spacing', 'bw-elementor-widgets' ),
+            'type'  => Controls_Manager::SLIDER,
+            'size_units' => [ 'px', '%' ],
+            'range' => [
+                'px' => [ 'min' => 0, 'max' => 200, 'step' => 1 ],
+                '%'  => [ 'min' => 0, 'max' => 30, 'step' => 1 ],
+            ],
+            'selectors' => [
+                '{{WRAPPER}} .bw-slick-slider' => 'padding-bottom: {{SIZE}}{{UNIT}};',
+            ],
+        ] );
+
+        $this->end_controls_section();
+
+        $this->start_controls_section( 'typography_section', [
+            'label' => __( 'Typography', 'bw-elementor-widgets' ),
+            'tab'   => Controls_Manager::TAB_STYLE,
+        ] );
+
+        $this->add_control( 'title_typography_heading', [
+            'label' => __( 'Titolo', 'bw-elementor-widgets' ),
+            'type'  => Controls_Manager::HEADING,
+        ] );
+
+        $this->add_group_control( Group_Control_Typography::get_type(), [
+            'name'     => 'title_typography',
+            'selector' => '{{WRAPPER}} .bw-slick-slider .bw-slick-title',
+        ] );
+
+        $this->add_responsive_control( 'title_margin_top', [
+            'label' => __( 'Margin Top', 'bw-elementor-widgets' ),
+            'type'  => Controls_Manager::SLIDER,
+            'size_units' => [ 'px' ],
+            'range' => [
+                'px' => [ 'min' => -100, 'max' => 200, 'step' => 1 ],
+            ],
+            'selectors' => [
+                '{{WRAPPER}} .bw-slick-slider .bw-slick-title' => 'margin-top: {{SIZE}}{{UNIT}};',
+            ],
+        ] );
+
+        $this->add_responsive_control( 'title_margin_bottom', [
+            'label' => __( 'Margin Bottom', 'bw-elementor-widgets' ),
+            'type'  => Controls_Manager::SLIDER,
+            'size_units' => [ 'px' ],
+            'range' => [
+                'px' => [ 'min' => -100, 'max' => 200, 'step' => 1 ],
+            ],
+            'selectors' => [
+                '{{WRAPPER}} .bw-slick-slider .bw-slick-title' => 'margin-bottom: {{SIZE}}{{UNIT}};',
+            ],
+        ] );
+
+        $this->add_control( 'description_typography_heading', [
+            'label' => __( 'Descrizione', 'bw-elementor-widgets' ),
+            'type'  => Controls_Manager::HEADING,
+            'separator' => 'before',
+        ] );
+
+        $this->add_group_control( Group_Control_Typography::get_type(), [
+            'name'     => 'description_typography',
+            'selector' => '{{WRAPPER}} .bw-slick-slider .bw-slick-description',
+        ] );
+
+        $this->add_responsive_control( 'description_margin_top', [
+            'label' => __( 'Margin Top', 'bw-elementor-widgets' ),
+            'type'  => Controls_Manager::SLIDER,
+            'size_units' => [ 'px' ],
+            'range' => [
+                'px' => [ 'min' => -100, 'max' => 200, 'step' => 1 ],
+            ],
+            'selectors' => [
+                '{{WRAPPER}} .bw-slick-slider .bw-slick-description' => 'margin-top: {{SIZE}}{{UNIT}};',
+            ],
+        ] );
+
+        $this->add_responsive_control( 'description_margin_bottom', [
+            'label' => __( 'Margin Bottom', 'bw-elementor-widgets' ),
+            'type'  => Controls_Manager::SLIDER,
+            'size_units' => [ 'px' ],
+            'range' => [
+                'px' => [ 'min' => -100, 'max' => 200, 'step' => 1 ],
+            ],
+            'selectors' => [
+                '{{WRAPPER}} .bw-slick-slider .bw-slick-description' => 'margin-bottom: {{SIZE}}{{UNIT}};',
+            ],
+        ] );
+
+        $this->add_control( 'price_typography_heading', [
+            'label' => __( 'Prezzo', 'bw-elementor-widgets' ),
+            'type'  => Controls_Manager::HEADING,
+            'separator' => 'before',
+        ] );
+
+        $this->add_group_control( Group_Control_Typography::get_type(), [
+            'name'     => 'price_typography',
+            'selector' => '{{WRAPPER}} .bw-slick-slider .bw-slick-price',
+        ] );
+
+        $this->add_responsive_control( 'price_margin_top', [
+            'label' => __( 'Margin Top', 'bw-elementor-widgets' ),
+            'type'  => Controls_Manager::SLIDER,
+            'size_units' => [ 'px' ],
+            'range' => [
+                'px' => [ 'min' => -100, 'max' => 200, 'step' => 1 ],
+            ],
+            'selectors' => [
+                '{{WRAPPER}} .bw-slick-slider .bw-slick-price' => 'margin-top: {{SIZE}}{{UNIT}};',
+            ],
+        ] );
+
+        $this->add_responsive_control( 'price_margin_bottom', [
+            'label' => __( 'Margin Bottom', 'bw-elementor-widgets' ),
+            'type'  => Controls_Manager::SLIDER,
+            'size_units' => [ 'px' ],
+            'range' => [
+                'px' => [ 'min' => -100, 'max' => 200, 'step' => 1 ],
+            ],
+            'selectors' => [
+                '{{WRAPPER}} .bw-slick-slider .bw-slick-price' => 'margin-bottom: {{SIZE}}{{UNIT}};',
+            ],
         ] );
 
         $this->end_controls_section();
@@ -404,18 +556,18 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
                             </div>
 
                             <div class="bw-slick-item__content">
-                                <h3 class="bw-slick-item__title">
+                                <h3 class="bw-slick-item__title bw-slick-title">
                                     <a href="<?php echo esc_url( $permalink ); ?>">
                                         <?php echo esc_html( $title ); ?>
                                     </a>
                                 </h3>
 
                                 <?php if ( ! empty( $excerpt ) ) : ?>
-                                    <div class="bw-slick-item__excerpt"><?php echo wp_kses_post( $excerpt ); ?></div>
+                                    <div class="bw-slick-item__excerpt bw-slick-description"><?php echo wp_kses_post( $excerpt ); ?></div>
                                 <?php endif; ?>
 
                                 <?php if ( $price_html ) : ?>
-                                    <div class="bw-slick-item__price price"><?php echo wp_kses_post( $price_html ); ?></div>
+                                    <div class="bw-slick-item__price price bw-slick-price"><?php echo wp_kses_post( $price_html ); ?></div>
                                 <?php endif; ?>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- add a Typography style tab for BW Slick Slider with responsive typography and margin controls for title, description, and price
- extend layout controls with responsive side padding and vertical spacing settings applied to the slider wrapper
- update markup and stylesheet to expose new classes for live preview styling adjustments

## Testing
- php -l includes/widgets/class-bw-slick-slider-widget.php

------
https://chatgpt.com/codex/tasks/task_e_68dd275ba6c88325b615a5138e88c8b0