### PR TITLE
Add customizable overlay buttons to BW Slick Slider

### DIFF
--- a/assets/css/bw-slick-slider.css
+++ b/assets/css/bw-slick-slider.css
@@ -4,6 +4,13 @@
   --bw-columns: 3;
   --bw-gap: 24px;
   --bw-image-height: auto;
+  --bw-overlay-buttons-background: #ffffff;
+  --bw-overlay-buttons-background-hover: #f5f5f5;
+  --bw-overlay-buttons-color: #000000;
+  --bw-overlay-buttons-color-hover: #000000;
+  --bw-overlay-buttons-radius: 12px;
+  --bw-overlay-buttons-padding-y: 12px;
+  --bw-overlay-buttons-padding-x: 16px;
 }
 
 .bw-slick-slider .slick-list {
@@ -79,52 +86,79 @@
   transform: scale(1.04);
 }
 
-.bw-slick-slider .bw-slick-item__overlay {
+.bw-slick-slider .overlay-buttons {
   position: absolute;
-  inset: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 16px;
-  background: rgba(0, 0, 0, 0.55);
+  gap: 0;
   opacity: 0;
-  visibility: hidden;
-  transition: opacity 0.3s ease, visibility 0.3s ease;
+  transform: translateY(10px);
+  transition: all 0.3s ease;
+  z-index: 2;
+  pointer-events: none;
 }
 
-.bw-slick-slider .bw-slick-item__inner:hover .bw-slick-item__overlay,
-.bw-slick-slider .bw-slick-item__inner:focus-within .bw-slick-item__overlay {
+.bw-slick-slider .bw-slick-item__inner:hover .overlay-buttons,
+.bw-slick-slider .bw-slick-item__inner:focus-within .overlay-buttons,
+.bw-slick-slider .bw-slick-item__image:hover .overlay-buttons {
   opacity: 1;
-  visibility: visible;
+  transform: translateY(0);
+  pointer-events: auto;
 }
 
-.bw-slick-slider .bw-slick-item__buttons {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  justify-content: center;
-}
-
-.bw-slick-slider .bw-slick-item__button {
+.bw-slick-slider .overlay-button {
+  position: relative;
   display: inline-flex;
-  align-items: center;
   justify-content: center;
-  padding: 0.65em 1.6em;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.75);
-  background-color: rgba(255, 255, 255, 0.92);
-  color: #0f0f0f;
-  font-weight: 600;
-  font-size: 0.95rem;
+  align-items: center;
+  width: 50%;
+  padding: var(--bw-overlay-buttons-padding-y) var(--bw-overlay-buttons-padding-x);
+  background: var(--bw-overlay-buttons-background);
+  color: var(--bw-overlay-buttons-color);
+  border: none;
+  border-radius: 0;
+  font-weight: 500;
   text-decoration: none;
-  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+  overflow: hidden;
+  transition: background 0.3s ease, color 0.3s ease;
 }
 
-.bw-slick-slider .bw-slick-item__button:hover,
-.bw-slick-slider .bw-slick-item__button:focus {
-  background-color: #0f0f0f;
-  border-color: #0f0f0f;
-  color: #ffffff;
+.bw-slick-slider .overlay-button:first-child {
+  border-top-left-radius: var(--bw-overlay-buttons-radius);
+  border-bottom-left-radius: var(--bw-overlay-buttons-radius);
+}
+
+.bw-slick-slider .overlay-button:last-child {
+  border-top-right-radius: var(--bw-overlay-buttons-radius);
+  border-bottom-right-radius: var(--bw-overlay-buttons-radius);
+}
+
+.bw-slick-slider .overlay-button + .overlay-button {
+  border-left: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.bw-slick-slider .overlay-button::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 8px;
+  width: 0;
+  height: 2px;
+  background: currentColor;
+  transition: width 0.3s ease;
+}
+
+.bw-slick-slider .overlay-button:hover,
+.bw-slick-slider .overlay-button:focus {
+  background: var(--bw-overlay-buttons-background-hover);
+  color: var(--bw-overlay-buttons-color-hover);
+}
+
+.bw-slick-slider .overlay-button:hover::after,
+.bw-slick-slider .overlay-button:focus::after {
+  width: 100%;
 }
 
 .bw-slick-slider .bw-slick-item__content {

--- a/includes/widgets/class-bw-slick-slider-widget.php
+++ b/includes/widgets/class-bw-slick-slider-widget.php
@@ -432,10 +432,121 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
         ] );
 
         $this->end_controls_section();
+
+        $this->start_controls_section( 'overlay_buttons_section', [
+            'label' => __( 'Overlay Buttons', 'bw-elementor-widgets' ),
+            'tab'   => Controls_Manager::TAB_STYLE,
+        ] );
+
+        $this->add_control( 'overlay_buttons_enable', [
+            'label'        => __( 'Enable Overlay Buttons', 'bw-elementor-widgets' ),
+            'type'         => Controls_Manager::SWITCHER,
+            'return_value' => 'yes',
+            'default'      => 'yes',
+        ] );
+
+        $this->add_group_control( Group_Control_Typography::get_type(), [
+            'name'      => 'overlay_buttons_typography',
+            'selector'  => '{{WRAPPER}} .bw-slick-slider .overlay-buttons a',
+            'condition' => [ 'overlay_buttons_enable' => 'yes' ],
+        ] );
+
+        $this->start_controls_tabs( 'overlay_buttons_color_tabs', [
+            'condition' => [ 'overlay_buttons_enable' => 'yes' ],
+        ] );
+
+        $this->start_controls_tab( 'overlay_buttons_color_normal', [
+            'label' => __( 'Normal', 'bw-elementor-widgets' ),
+        ] );
+
+        $this->add_control( 'overlay_buttons_text_color', [
+            'label'     => __( 'Text Color', 'bw-elementor-widgets' ),
+            'type'      => Controls_Manager::COLOR,
+            'default'   => '#000000',
+            'selectors' => [
+                '{{WRAPPER}} .bw-slick-slider' => '--bw-overlay-buttons-color: {{VALUE}};',
+            ],
+        ] );
+
+        $this->add_control( 'overlay_buttons_background_color', [
+            'label'     => __( 'Background Color', 'bw-elementor-widgets' ),
+            'type'      => Controls_Manager::COLOR,
+            'default'   => '#ffffff',
+            'selectors' => [
+                '{{WRAPPER}} .bw-slick-slider' => '--bw-overlay-buttons-background: {{VALUE}};',
+            ],
+        ] );
+
+        $this->end_controls_tab();
+
+        $this->start_controls_tab( 'overlay_buttons_color_hover', [
+            'label' => __( 'Hover', 'bw-elementor-widgets' ),
+        ] );
+
+        $this->add_control( 'overlay_buttons_text_color_hover', [
+            'label'     => __( 'Text Color', 'bw-elementor-widgets' ),
+            'type'      => Controls_Manager::COLOR,
+            'default'   => '#000000',
+            'selectors' => [
+                '{{WRAPPER}} .bw-slick-slider' => '--bw-overlay-buttons-color-hover: {{VALUE}};',
+            ],
+        ] );
+
+        $this->add_control( 'overlay_buttons_background_color_hover', [
+            'label'     => __( 'Background Color', 'bw-elementor-widgets' ),
+            'type'      => Controls_Manager::COLOR,
+            'default'   => '#f5f5f5',
+            'selectors' => [
+                '{{WRAPPER}} .bw-slick-slider' => '--bw-overlay-buttons-background-hover: {{VALUE}};',
+            ],
+        ] );
+
+        $this->end_controls_tab();
+
+        $this->end_controls_tabs();
+
+        $this->add_responsive_control( 'overlay_buttons_border_radius', [
+            'label'     => __( 'Border Radius', 'bw-elementor-widgets' ),
+            'type'      => Controls_Manager::SLIDER,
+            'size_units'=> [ 'px' ],
+            'range'     => [ 'px' => [ 'min' => 0, 'max' => 60, 'step' => 1 ] ],
+            'default'   => [ 'size' => 12, 'unit' => 'px' ],
+            'selectors' => [
+                '{{WRAPPER}} .bw-slick-slider' => '--bw-overlay-buttons-radius: {{SIZE}}{{UNIT}};',
+            ],
+            'condition' => [ 'overlay_buttons_enable' => 'yes' ],
+        ] );
+
+        $this->add_responsive_control( 'overlay_buttons_padding_vertical', [
+            'label'     => __( 'Vertical Padding', 'bw-elementor-widgets' ),
+            'type'      => Controls_Manager::SLIDER,
+            'size_units'=> [ 'px' ],
+            'range'     => [ 'px' => [ 'min' => 0, 'max' => 60, 'step' => 1 ] ],
+            'default'   => [ 'size' => 12, 'unit' => 'px' ],
+            'selectors' => [
+                '{{WRAPPER}} .bw-slick-slider' => '--bw-overlay-buttons-padding-y: {{SIZE}}{{UNIT}};',
+            ],
+            'condition' => [ 'overlay_buttons_enable' => 'yes' ],
+        ] );
+
+        $this->add_responsive_control( 'overlay_buttons_padding_horizontal', [
+            'label'     => __( 'Horizontal Padding', 'bw-elementor-widgets' ),
+            'type'      => Controls_Manager::SLIDER,
+            'size_units'=> [ 'px' ],
+            'range'     => [ 'px' => [ 'min' => 0, 'max' => 80, 'step' => 1 ] ],
+            'default'   => [ 'size' => 16, 'unit' => 'px' ],
+            'selectors' => [
+                '{{WRAPPER}} .bw-slick-slider' => '--bw-overlay-buttons-padding-x: {{SIZE}}{{UNIT}};',
+            ],
+            'condition' => [ 'overlay_buttons_enable' => 'yes' ],
+        ] );
+
+        $this->end_controls_section();
     }
 
     protected function render() {
         $settings      = $this->get_settings_for_display();
+        $overlay_buttons_enabled = isset( $settings['overlay_buttons_enable'] ) && 'yes' === $settings['overlay_buttons_enable'];
         $content_type  = isset( $settings['content_type'] ) && 'product' === $settings['content_type'] ? 'product' : 'post';
         $columns       = isset( $settings['columns'] ) ? max( 1, absint( $settings['columns'] ) ) : 3;
         $gap           = isset( $settings['gap']['size'] ) ? max( 0, absint( $settings['gap']['size'] ) ) : 24;
@@ -543,16 +654,16 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
                                 <?php else : ?>
                                     <span class="bw-slick-item__image-placeholder" aria-hidden="true"></span>
                                 <?php endif; ?>
-                                <div class="bw-slick-item__overlay">
-                                    <div class="bw-slick-item__buttons">
-                                        <a class="bw-slick-item__button bw-slick-item__button--view" href="<?php echo esc_url( $permalink ); ?>">
+                                <?php if ( $overlay_buttons_enabled ) : ?>
+                                    <div class="overlay-buttons">
+                                        <a class="overlay-button overlay-button--view" href="<?php echo esc_url( $permalink ); ?>">
                                             <?php esc_html_e( 'View Product', 'bw-elementor-widgets' ); ?>
                                         </a>
-                                        <a class="bw-slick-item__button bw-slick-item__button--quick" href="<?php echo esc_url( $quick_view_link ); ?>">
+                                        <a class="overlay-button overlay-button--quick" href="<?php echo esc_url( $quick_view_link ); ?>">
                                             <?php esc_html_e( 'Quick View', 'bw-elementor-widgets' ); ?>
                                         </a>
                                     </div>
-                                </div>
+                                <?php endif; ?>
                             </div>
 
                             <div class="bw-slick-item__content">


### PR DESCRIPTION
## Summary
- add an Elementor Overlay Buttons style section with toggle, typography, color, radius, and padding controls
- render the slider cards with a dedicated overlay button container that can be switched off
- restyle the slider CSS to show side-by-side animated overlay buttons that reveal on hover

## Testing
- php -l includes/widgets/class-bw-slick-slider-widget.php

------
https://chatgpt.com/codex/tasks/task_e_68dd471b0d608325a45819c9e1c9e982