### PR TITLE
Add WooCommerce product types for digital, book, and print

### DIFF
--- a/bw-main-elementor-widgets.php
+++ b/bw-main-elementor-widgets.php
@@ -20,6 +20,9 @@ if ( file_exists( plugin_dir_path( __FILE__ ) . 'BW_coming_soon/bw-coming-soon.p
 // Loader dei widget
 require_once __DIR__ . '/includes/class-bw-widget-loader.php';
 
+// Tipi di prodotto personalizzati per WooCommerce
+require_once plugin_dir_path( __FILE__ ) . 'includes/product-types/product-types-init.php';
+
 add_action('elementor/frontend/after_enqueue_scripts', 'bw_enqueue_flickity');
 add_action('elementor/editor/after_enqueue_scripts', 'bw_enqueue_flickity');
 

--- a/includes/product-types/class-bw-product-type-book.php
+++ b/includes/product-types/class-bw-product-type-book.php
@@ -1,0 +1,37 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( class_exists( 'WC_Product_Simple' ) && ! class_exists( 'WC_Product_Book' ) ) {
+
+class WC_Product_Book extends WC_Product_Simple {
+
+    /**
+     * Product type identifier.
+     *
+     * @var string
+     */
+    protected $product_type = 'book';
+
+    /**
+     * WC_Product_Book constructor.
+     *
+     * @param mixed $product Product to initialize.
+     */
+    public function __construct( $product = 0 ) {
+        parent::__construct( $product );
+    }
+
+    /**
+     * Get the product type.
+     *
+     * @return string
+     */
+    public function get_type() {
+        return 'book';
+    }
+}
+
+}

--- a/includes/product-types/class-bw-product-type-digital.php
+++ b/includes/product-types/class-bw-product-type-digital.php
@@ -1,0 +1,37 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( class_exists( 'WC_Product_Simple' ) && ! class_exists( 'WC_Product_Digital_Asset' ) ) {
+
+class WC_Product_Digital_Asset extends WC_Product_Simple {
+
+    /**
+     * Product type identifier.
+     *
+     * @var string
+     */
+    protected $product_type = 'digital_asset';
+
+    /**
+     * WC_Product_Digital_Asset constructor.
+     *
+     * @param mixed $product Product to initialize.
+     */
+    public function __construct( $product = 0 ) {
+        parent::__construct( $product );
+    }
+
+    /**
+     * Get the product type.
+     *
+     * @return string
+     */
+    public function get_type() {
+        return 'digital_asset';
+    }
+}
+
+}

--- a/includes/product-types/class-bw-product-type-print.php
+++ b/includes/product-types/class-bw-product-type-print.php
@@ -1,0 +1,37 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( class_exists( 'WC_Product_Simple' ) && ! class_exists( 'WC_Product_Print' ) ) {
+
+class WC_Product_Print extends WC_Product_Simple {
+
+    /**
+     * Product type identifier.
+     *
+     * @var string
+     */
+    protected $product_type = 'print';
+
+    /**
+     * WC_Product_Print constructor.
+     *
+     * @param mixed $product Product to initialize.
+     */
+    public function __construct( $product = 0 ) {
+        parent::__construct( $product );
+    }
+
+    /**
+     * Get the product type.
+     *
+     * @return string
+     */
+    public function get_type() {
+        return 'print';
+    }
+}
+
+}

--- a/includes/product-types/product-types-init.php
+++ b/includes/product-types/product-types-init.php
@@ -1,0 +1,133 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+require_once plugin_dir_path( __FILE__ ) . 'class-bw-product-type-digital.php';
+require_once plugin_dir_path( __FILE__ ) . 'class-bw-product-type-book.php';
+require_once plugin_dir_path( __FILE__ ) . 'class-bw-product-type-print.php';
+
+/**
+ * Register custom product types and related functionality.
+ */
+function bw_register_custom_product_types() {
+    if ( ! class_exists( 'WooCommerce' ) ) {
+        return;
+    }
+
+    add_filter( 'product_type_selector', 'bw_add_product_type_options' );
+    add_filter( 'woocommerce_product_class', 'bw_register_product_type_classes', 10, 2 );
+    add_action( 'admin_menu', 'bw_register_product_type_admin_menu', 99 );
+}
+add_action( 'init', 'bw_register_custom_product_types' );
+
+/**
+ * Add custom product types to the product type selector dropdown.
+ *
+ * @param array $types Existing product types.
+ *
+ * @return array
+ */
+function bw_add_product_type_options( $types ) {
+    $types['digital_asset'] = __( 'Digital Assets', 'bw-main-elementor-widgets' );
+    $types['book']          = __( 'Books', 'bw-main-elementor-widgets' );
+    $types['print']         = __( 'Prints', 'bw-main-elementor-widgets' );
+
+    return $types;
+}
+
+/**
+ * Map custom product type slugs to their respective classes.
+ *
+ * @param string $classname Class name determined by WooCommerce.
+ * @param string $product_type Product type slug.
+ *
+ * @return string
+ */
+function bw_register_product_type_classes( $classname, $product_type ) {
+    switch ( $product_type ) {
+        case 'digital_asset':
+            $classname = WC_Product_Digital_Asset::class;
+            break;
+        case 'book':
+            $classname = WC_Product_Book::class;
+            break;
+        case 'print':
+            $classname = WC_Product_Print::class;
+            break;
+    }
+
+    return $classname;
+}
+
+/**
+ * Register submenu pages for the custom product types.
+ */
+function bw_register_product_type_admin_menu() {
+    if ( ! class_exists( 'WooCommerce' ) ) {
+        return;
+    }
+
+    add_submenu_page(
+        'edit.php?post_type=product',
+        __( 'Digital Assets', 'bw-main-elementor-widgets' ),
+        __( 'Digital Assets', 'bw-main-elementor-widgets' ),
+        'manage_woocommerce',
+        'bw-digital-asset-products',
+        'bw_render_digital_asset_products_page'
+    );
+
+    add_submenu_page(
+        'edit.php?post_type=product',
+        __( 'Books', 'bw-main-elementor-widgets' ),
+        __( 'Books', 'bw-main-elementor-widgets' ),
+        'manage_woocommerce',
+        'bw-book-products',
+        'bw_render_book_products_page'
+    );
+
+    add_submenu_page(
+        'edit.php?post_type=product',
+        __( 'Prints', 'bw-main-elementor-widgets' ),
+        __( 'Prints', 'bw-main-elementor-widgets' ),
+        'manage_woocommerce',
+        'bw-print-products',
+        'bw_render_print_products_page'
+    );
+}
+
+/**
+ * Redirect submenu pages to the filtered product list.
+ */
+function bw_render_digital_asset_products_page() {
+    bw_redirect_to_product_type_list( 'digital_asset' );
+}
+
+/**
+ * Redirect submenu pages to the filtered product list.
+ */
+function bw_render_book_products_page() {
+    bw_redirect_to_product_type_list( 'book' );
+}
+
+/**
+ * Redirect submenu pages to the filtered product list.
+ */
+function bw_render_print_products_page() {
+    bw_redirect_to_product_type_list( 'print' );
+}
+
+/**
+ * Helper to redirect to the edit screen filtered by product type.
+ *
+ * @param string $product_type Product type slug.
+ */
+function bw_redirect_to_product_type_list( $product_type ) {
+    if ( ! current_user_can( 'manage_woocommerce' ) ) {
+        wp_die( esc_html__( 'You do not have permission to access this page.', 'bw-main-elementor-widgets' ) );
+    }
+
+    wp_safe_redirect( admin_url( 'edit.php?post_type=product&product_type=' . $product_type ) );
+    exit;
+}


### PR DESCRIPTION
## Summary
- add WooCommerce product type classes for digital assets, books, and prints
- register the product type selector options, class mappings, and admin submenu redirects when WooCommerce is active
- load the custom product type bootstrap from the main plugin file

## Testing
- php -l includes/product-types/product-types-init.php
- php -l includes/product-types/class-bw-product-type-digital.php
- php -l includes/product-types/class-bw-product-type-book.php
- php -l includes/product-types/class-bw-product-type-print.php

------
https://chatgpt.com/codex/tasks/task_e_68de52e6d604832599429ccc8638c5be