### PR TITLE
Enable variable features for custom product types

### DIFF
--- a/includes/product-types/class-bw-product-type-book.php
+++ b/includes/product-types/class-bw-product-type-book.php
@@ -4,9 +4,9 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( class_exists( 'WC_Product_Simple' ) && ! class_exists( 'WC_Product_Book' ) ) {
+if ( class_exists( 'WC_Product_Variable' ) && ! class_exists( 'WC_Product_Book' ) ) {
 
-class WC_Product_Book extends WC_Product_Simple {
+class WC_Product_Book extends WC_Product_Variable {
 
     /**
      * Product type identifier.

--- a/includes/product-types/class-bw-product-type-digital.php
+++ b/includes/product-types/class-bw-product-type-digital.php
@@ -4,9 +4,9 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( class_exists( 'WC_Product_Simple' ) && ! class_exists( 'WC_Product_Digital_Asset' ) ) {
+if ( class_exists( 'WC_Product_Variable' ) && ! class_exists( 'WC_Product_Digital_Asset' ) ) {
 
-class WC_Product_Digital_Asset extends WC_Product_Simple {
+class WC_Product_Digital_Asset extends WC_Product_Variable {
 
     /**
      * Product type identifier.

--- a/includes/product-types/class-bw-product-type-print.php
+++ b/includes/product-types/class-bw-product-type-print.php
@@ -4,9 +4,9 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( class_exists( 'WC_Product_Simple' ) && ! class_exists( 'WC_Product_Print' ) ) {
+if ( class_exists( 'WC_Product_Variable' ) && ! class_exists( 'WC_Product_Print' ) ) {
 
-class WC_Product_Print extends WC_Product_Simple {
+class WC_Product_Print extends WC_Product_Variable {
 
     /**
      * Product type identifier.

--- a/includes/product-types/product-types-init.php
+++ b/includes/product-types/product-types-init.php
@@ -8,6 +8,37 @@ require_once plugin_dir_path( __FILE__ ) . 'class-bw-product-type-digital.php';
 require_once plugin_dir_path( __FILE__ ) . 'class-bw-product-type-book.php';
 require_once plugin_dir_path( __FILE__ ) . 'class-bw-product-type-print.php';
 
+// Mostrare le tabs di attributi, variazioni, spedizione anche per i custom types.
+add_filter( 'woocommerce_product_data_tabs', function( $tabs ) {
+    $custom_types = [ 'digital_asset', 'book', 'print' ];
+
+    foreach ( $custom_types as $type ) {
+        $tabs['attribute']['class'][]  = 'show_if_' . $type;
+        $tabs['variations']['class'][] = 'show_if_' . $type;
+        $tabs['shipping']['class'][]   = 'show_if_' . $type;
+        $tabs['inventory']['class'][]  = 'show_if_' . $type;
+    }
+
+    return $tabs;
+} );
+
+// Aggiungere le sezioni pannelli variabili.
+add_action( 'admin_footer', function() {
+    global $pagenow, $post;
+
+    if ( $pagenow === 'post.php' && $post instanceof WP_Post && get_post_type( $post ) === 'product' ) : ?>
+        <script type="text/javascript">
+            jQuery(document).ready(function($){
+                var custom_types = ['digital_asset','book','print'];
+                custom_types.forEach(function(type){
+                    $('.options_group.show_if_variable').addClass('show_if_' + type);
+                    $('#variable_product_options').addClass('show_if_' + type);
+                });
+            });
+        </script>
+    <?php endif;
+} );
+
 /**
  * Register custom product types and related functionality.
  */


### PR DESCRIPTION
## Summary
- extend the digital asset, book, and print product classes from `WC_Product_Variable` to support WooCommerce variation features
- expose the attribute, variation, inventory, and shipping tabs/panels in the product editor for the custom product types

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de57b48d448325a5235e5941e7f5ca