### PR TITLE
Adjust WooCommerce product types

### DIFF
--- a/includes/product-types/class-bw-product-type-book.php
+++ b/includes/product-types/class-bw-product-type-book.php
@@ -4,9 +4,9 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( class_exists( 'WC_Product_Variable' ) && ! class_exists( 'WC_Product_Book' ) ) {
+if ( class_exists( 'WC_Product_Simple' ) && ! class_exists( 'WC_Product_Book' ) ) {
 
-class WC_Product_Book extends WC_Product_Variable {
+class WC_Product_Book extends WC_Product_Simple {
 
     /**
      * Product type identifier.
@@ -14,15 +14,6 @@ class WC_Product_Book extends WC_Product_Variable {
      * @var string
      */
     protected $product_type = 'book';
-
-    /**
-     * WC_Product_Book constructor.
-     *
-     * @param mixed $product Product to initialize.
-     */
-    public function __construct( $product = 0 ) {
-        parent::__construct( $product );
-    }
 
     /**
      * Get the product type.

--- a/includes/product-types/class-bw-product-type-digital.php
+++ b/includes/product-types/class-bw-product-type-digital.php
@@ -16,12 +16,21 @@ class WC_Product_Digital_Asset extends WC_Product_Variable {
     protected $product_type = 'digital_asset';
 
     /**
-     * WC_Product_Digital_Asset constructor.
+     * Always treat digital assets as virtual products.
      *
-     * @param mixed $product Product to initialize.
+     * @return bool
      */
-    public function __construct( $product = 0 ) {
-        parent::__construct( $product );
+    public function is_virtual() {
+        return true;
+    }
+
+    /**
+     * Always treat digital assets as downloadable products.
+     *
+     * @return bool
+     */
+    public function is_downloadable() {
+        return true;
     }
 
     /**

--- a/includes/product-types/class-bw-product-type-print.php
+++ b/includes/product-types/class-bw-product-type-print.php
@@ -4,9 +4,9 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( class_exists( 'WC_Product_Variable' ) && ! class_exists( 'WC_Product_Print' ) ) {
+if ( class_exists( 'WC_Product_Simple' ) && ! class_exists( 'WC_Product_Print' ) ) {
 
-class WC_Product_Print extends WC_Product_Variable {
+class WC_Product_Print extends WC_Product_Simple {
 
     /**
      * Product type identifier.
@@ -14,15 +14,6 @@ class WC_Product_Print extends WC_Product_Variable {
      * @var string
      */
     protected $product_type = 'print';
-
-    /**
-     * WC_Product_Print constructor.
-     *
-     * @param mixed $product Product to initialize.
-     */
-    public function __construct( $product = 0 ) {
-        parent::__construct( $product );
-    }
 
     /**
      * Get the product type.

--- a/includes/product-types/product-types-init.php
+++ b/includes/product-types/product-types-init.php
@@ -8,32 +8,46 @@ require_once plugin_dir_path( __FILE__ ) . 'class-bw-product-type-digital.php';
 require_once plugin_dir_path( __FILE__ ) . 'class-bw-product-type-book.php';
 require_once plugin_dir_path( __FILE__ ) . 'class-bw-product-type-print.php';
 
-// Mostrare le tabs di attributi, variazioni, spedizione anche per i custom types.
+// Personalizzazione tabs prodotto per i digital asset.
 add_filter( 'woocommerce_product_data_tabs', function( $tabs ) {
-    $custom_types = [ 'digital_asset', 'book', 'print' ];
+    if ( isset( $tabs['attribute'] ) ) {
+        $tabs['attribute']['class'][] = 'show_if_digital_asset';
+    }
 
-    foreach ( $custom_types as $type ) {
-        $tabs['attribute']['class'][]  = 'show_if_' . $type;
-        $tabs['variations']['class'][] = 'show_if_' . $type;
-        $tabs['shipping']['class'][]   = 'show_if_' . $type;
-        $tabs['inventory']['class'][]  = 'show_if_' . $type;
+    if ( isset( $tabs['variations'] ) ) {
+        $tabs['variations']['class'][] = 'show_if_digital_asset';
+    }
+
+    if ( isset( $tabs['inventory'] ) ) {
+        $tabs['inventory']['class'][] = 'show_if_digital_asset';
+    }
+
+    if ( isset( $tabs['shipping'] ) ) {
+        $tabs['shipping']['class'][] = 'hide_if_digital_asset';
     }
 
     return $tabs;
 } );
 
-// Aggiungere le sezioni pannelli variabili.
+// Attivare i pannelli variabili per i digital asset.
 add_action( 'admin_footer', function() {
     global $pagenow, $post;
 
-    if ( $pagenow === 'post.php' && $post instanceof WP_Post && get_post_type( $post ) === 'product' ) : ?>
+    $is_product_screen = false;
+
+    if ( in_array( $pagenow, array( 'post.php', 'post-new.php' ), true ) ) {
+        if ( $post instanceof WP_Post ) {
+            $is_product_screen = ( 'product' === get_post_type( $post ) );
+        } elseif ( isset( $_GET['post_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+            $is_product_screen = ( 'product' === sanitize_text_field( wp_unslash( $_GET['post_type'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        }
+    }
+
+    if ( $is_product_screen ) : ?>
         <script type="text/javascript">
             jQuery(document).ready(function($){
-                var custom_types = ['digital_asset','book','print'];
-                custom_types.forEach(function(type){
-                    $('.options_group.show_if_variable').addClass('show_if_' + type);
-                    $('#variable_product_options').addClass('show_if_' + type);
-                });
+                $('.options_group.show_if_variable').addClass('show_if_digital_asset');
+                $('#variable_product_options').addClass('show_if_digital_asset');
             });
         </script>
     <?php endif;


### PR DESCRIPTION
## Summary
- ensure the Digital Asset product type always behaves as a virtual, downloadable variable product
- register Book and Print product types as physical simple products
- tailor WooCommerce admin tabs so Digital Assets expose attributes, variations, and inventory while hiding shipping

## Testing
- php -l includes/product-types/class-bw-product-type-digital.php
- php -l includes/product-types/class-bw-product-type-book.php
- php -l includes/product-types/class-bw-product-type-print.php
- php -l includes/product-types/product-types-init.php

------
https://chatgpt.com/codex/tasks/task_e_68de60f2f62883258f7d47e3949c0807