### PR TITLE
Enable WooCommerce simple options for book and print products

### DIFF
--- a/includes/product-types/product-types-init.php
+++ b/includes/product-types/product-types-init.php
@@ -26,6 +26,30 @@ add_filter( 'woocommerce_product_data_tabs', function( $tabs ) {
         $tabs['shipping']['class'][] = 'hide_if_digital_asset';
     }
 
+    $custom_simple_types = array( 'book', 'print' );
+
+    foreach ( $custom_simple_types as $type ) {
+        if ( isset( $tabs['general'] ) ) {
+            $tabs['general']['class'][] = 'show_if_' . $type;
+        }
+
+        if ( isset( $tabs['inventory'] ) ) {
+            $tabs['inventory']['class'][] = 'show_if_' . $type;
+        }
+
+        if ( isset( $tabs['shipping'] ) ) {
+            $tabs['shipping']['class'][] = 'show_if_' . $type;
+        }
+
+        if ( isset( $tabs['linked_product'] ) ) {
+            $tabs['linked_product']['class'][] = 'show_if_' . $type;
+        }
+
+        if ( isset( $tabs['advanced'] ) ) {
+            $tabs['advanced']['class'][] = 'show_if_' . $type;
+        }
+    }
+
     return $tabs;
 } );
 
@@ -48,6 +72,12 @@ add_action( 'admin_footer', function() {
             jQuery(document).ready(function($){
                 $('.options_group.show_if_variable').addClass('show_if_digital_asset');
                 $('#variable_product_options').addClass('show_if_digital_asset');
+
+                var custom_simple = ['book', 'print'];
+
+                custom_simple.forEach(function(type){
+                    $('.show_if_simple').addClass('show_if_' + type);
+                });
             });
         </script>
     <?php endif;


### PR DESCRIPTION
## Summary
- expose the general, inventory, shipping, linked products, and advanced tabs for the book and print product types
- mirror simple product field visibility rules for book and print products in the admin UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de638138148325884510ad0b74c2b9