### PR TITLE
Add dependent product category controls to BW Slick Slider

### DIFF
--- a/assets/js/bw-slick-slider-admin.js
+++ b/assets/js/bw-slick-slider-admin.js
@@ -1,0 +1,166 @@
+(function ($) {
+    'use strict';
+
+    var settings = window.bwSlickSliderAdmin || {};
+    var ajaxUrl = settings.ajaxUrl || window.ajaxurl || '';
+    var nonce = settings.nonce || '';
+
+    var selectors = {
+        parent: 'select[data-setting="product_cat_parent"]',
+        child: 'select[data-setting="product_cat_child"]'
+    };
+
+    function getSettingValue(model, setting) {
+        if (!model) {
+            return '';
+        }
+
+        if (typeof model.getSetting === 'function') {
+            return model.getSetting(setting);
+        }
+
+        var settingsModel = model.get && model.get('settings');
+        if (settingsModel && typeof settingsModel.get === 'function') {
+            return settingsModel.get(setting);
+        }
+
+        return '';
+    }
+
+    function getChildSelect($parentSelect) {
+        var $controlsWrapper = $parentSelect.closest('.elementor-control').parent();
+
+        if (!$controlsWrapper.length) {
+            $controlsWrapper = $parentSelect.closest('.elementor-control');
+        }
+
+        return $controlsWrapper.find(selectors.child).first();
+    }
+
+    function resetChildSelect($childSelect) {
+        if (!$childSelect.length) {
+            return;
+        }
+
+        $childSelect.empty();
+        $childSelect.prop('disabled', true);
+        $childSelect.val([]);
+        $childSelect.trigger('change');
+    }
+
+    function populateChildSelect($childSelect, options, selectedValues) {
+        if (!$childSelect.length) {
+            return;
+        }
+
+        $childSelect.empty();
+
+        var selected = Array.isArray(selectedValues) ? selectedValues.map(String) : [];
+        var hasOptions = false;
+
+        $.each(options, function (value, label) {
+            hasOptions = true;
+            var stringValue = String(value);
+            var $option = $('<option></option>').attr('value', stringValue).text(label);
+
+            if (selected.indexOf(stringValue) !== -1) {
+                $option.prop('selected', true);
+            }
+
+            $childSelect.append($option);
+        });
+
+        $childSelect.prop('disabled', !hasOptions);
+        $childSelect.trigger('change');
+    }
+
+    function fetchChildCategories(parentId, callback) {
+        if (!ajaxUrl) {
+            callback({});
+            return;
+        }
+
+        $.post(ajaxUrl, {
+            action: 'bw_get_child_categories',
+            parent_id: parentId,
+            nonce: nonce
+        })
+            .done(function (response) {
+                if (response && response.success && response.data) {
+                    callback(response.data);
+                } else {
+                    callback({});
+                }
+            })
+            .fail(function () {
+                callback({});
+            });
+    }
+
+    function handleParentChange(event) {
+        var $parent = $(event.currentTarget);
+        var parentId = $parent.val();
+        var $childSelect = getChildSelect($parent);
+
+        if (!parentId) {
+            resetChildSelect($childSelect);
+            return;
+        }
+
+        resetChildSelect($childSelect);
+
+        fetchChildCategories(parentId, function (options) {
+            populateChildSelect($childSelect, options, []);
+        });
+    }
+
+    function initializePanel(panel, model, view) {
+        if (!model || model.get('widgetType') !== 'bw-slick-slider') {
+            return;
+        }
+
+        var parentId = getSettingValue(model, 'product_cat_parent');
+        var childValues = getSettingValue(model, 'product_cat_child');
+
+        if (!Array.isArray(childValues)) {
+            childValues = childValues ? [childValues] : [];
+        }
+
+        setTimeout(function () {
+            var $context = panel && panel.$el ? panel.$el : (view && view.$el ? view.$el : $());
+            var $parentSelect = $context.find(selectors.parent).first();
+            var $childSelect = $context.find(selectors.child).first();
+
+            if (!$childSelect.length) {
+                return;
+            }
+
+            if (parentId) {
+                fetchChildCategories(parentId, function (options) {
+                    populateChildSelect($childSelect, options, childValues);
+                });
+            } else {
+                resetChildSelect($childSelect);
+            }
+        }, 100);
+    }
+
+    $(document).on('change', selectors.parent, handleParentChange);
+
+    $(document).ready(function () {
+        $(selectors.child).each(function () {
+            var $child = $(this);
+            if (!$child.prop('disabled')) {
+                $child.prop('disabled', !$child.val());
+            }
+        });
+    });
+
+    $(window).on('elementor:init', function () {
+        if (window.elementor && window.elementor.hooks) {
+            window.elementor.hooks.addAction('panel/open_editor/widget/bw-slick-slider', function (panel, model, view) {
+                initializePanel(panel, model, view);
+            });
+        }
+    });
+})(jQuery);

--- a/bw-main-elementor-widgets.php
+++ b/bw-main-elementor-widgets.php
@@ -17,6 +17,9 @@ if ( file_exists( plugin_dir_path( __FILE__ ) . 'BW_coming_soon/bw-coming-soon.p
 }
 
 
+// Helper functions
+require_once __DIR__ . '/includes/helpers.php';
+
 // Loader dei widget
 require_once __DIR__ . '/includes/class-bw-widget-loader.php';
 
@@ -25,6 +28,7 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/product-types/product-types
 
 add_action('elementor/frontend/after_enqueue_scripts', 'bw_enqueue_flickity');
 add_action('elementor/editor/after_enqueue_scripts', 'bw_enqueue_flickity');
+add_action('elementor/editor/after_enqueue_scripts', 'bw_enqueue_slick_slider_admin_script');
 
 function bw_enqueue_flickity() {
     wp_enqueue_style(
@@ -83,6 +87,25 @@ function bw_enqueue_flickity() {
         ['jquery', 'slick-js'],
         '1.0.0',
         true
+    );
+}
+
+function bw_enqueue_slick_slider_admin_script() {
+    wp_enqueue_script(
+        'bw-slick-slider-admin',
+        plugin_dir_url(__FILE__) . 'assets/js/bw-slick-slider-admin.js',
+        ['jquery'],
+        '1.0.0',
+        true
+    );
+
+    wp_localize_script(
+        'bw-slick-slider-admin',
+        'bwSlickSliderAdmin',
+        [
+            'ajaxUrl' => admin_url('admin-ajax.php'),
+            'nonce'   => wp_create_nonce('bw_get_child_categories'),
+        ]
     );
 }
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1,0 +1,74 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! function_exists( 'bw_get_parent_product_categories' ) ) {
+    /**
+     * Retrieve WooCommerce top-level product categories.
+     *
+     * @return array<int,string>
+     */
+    function bw_get_parent_product_categories() {
+        $terms = get_terms(
+            [
+                'taxonomy'   => 'product_cat',
+                'hide_empty' => false,
+                'parent'     => 0,
+            ]
+        );
+
+        $options = [];
+
+        if ( empty( $terms ) || is_wp_error( $terms ) ) {
+            return $options;
+        }
+
+        foreach ( $terms as $term ) {
+            $options[ $term->term_id ] = $term->name;
+        }
+
+        return $options;
+    }
+}
+
+if ( ! function_exists( 'bw_ajax_get_child_categories' ) ) {
+    /**
+     * AJAX callback to fetch child categories for a given parent category.
+     */
+    function bw_ajax_get_child_categories() {
+        if ( ! current_user_can( 'edit_posts' ) ) {
+            wp_send_json_error();
+        }
+
+        check_ajax_referer( 'bw_get_child_categories', 'nonce' );
+
+        $parent_id = isset( $_POST['parent_id'] ) ? absint( $_POST['parent_id'] ) : 0;
+
+        if ( $parent_id <= 0 ) {
+            wp_send_json_success( [] );
+        }
+
+        $terms = get_terms(
+            [
+                'taxonomy'   => 'product_cat',
+                'hide_empty' => false,
+                'parent'     => $parent_id,
+            ]
+        );
+
+        if ( is_wp_error( $terms ) || empty( $terms ) ) {
+            wp_send_json_success( [] );
+        }
+
+        $options = [];
+
+        foreach ( $terms as $term ) {
+            $options[ $term->term_id ] = $term->name;
+        }
+
+        wp_send_json_success( $options );
+    }
+}
+
+add_action( 'wp_ajax_bw_get_child_categories', 'bw_ajax_get_child_categories' );


### PR DESCRIPTION
## Summary
- rename the BW Slick Slider product category control to a parent-only selector and add a dependent sub-category field
- add helper utilities and an authenticated AJAX endpoint to fetch child product categories for the Elementor editor
- update the widget product query to prioritise selected sub-categories and fall back to the chosen parent category

## Testing
- php -l wpblackwork/includes/widgets/class-bw-slick-slider-widget.php
- php -l wpblackwork/includes/helpers.php
- php -l wpblackwork/bw-main-elementor-widgets.php

------
https://chatgpt.com/codex/tasks/task_e_68de6d3d12608325870ab416fe2d87a1