### PR TITLE
Add Elementor arrow styling controls for BW Slick Slider

### DIFF
--- a/assets/css/bw-slick-slider.css
+++ b/assets/css/bw-slick-slider.css
@@ -202,6 +202,24 @@
   text-decoration: underline;
 }
 
+.bw-slick-prev,
+.bw-slick-next {
+  position: absolute;
+  bottom: 15px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  z-index: 10;
+}
+
+.bw-slick-prev {
+  right: 55px;
+}
+
+.bw-slick-next {
+  right: 15px;
+}
+
 .bw-slick-slider .bw-slick-item__excerpt,
 .bw-slick-slider .bw-slick-description {
   color: #4b4b4b;

--- a/assets/js/bw-slick-slider.js
+++ b/assets/js/bw-slick-slider.js
@@ -1,6 +1,18 @@
 (function ($) {
   'use strict';
 
+  var ensureTrailingSlash = function (path) {
+    if (typeof path !== 'string' || !path.length) {
+      return '';
+    }
+
+    return path.charAt(path.length - 1) === '/' ? path : path + '/';
+  };
+
+  var assetsUrl = ensureTrailingSlash(
+    (window.bwSlickSlider && window.bwSlickSlider.assetsUrl) || ''
+  );
+
   var normalizeBoolean = function (value, fallback) {
     if (typeof value === 'boolean') {
       return value;
@@ -193,6 +205,20 @@
       }
 
       var settings = parseSettings($currentSlider);
+
+      if (typeof settings.prevArrow === 'undefined') {
+        settings.prevArrow =
+          '<button type="button" class="bw-slick-prev"><img src="' +
+          assetsUrl +
+          'img/arrow-l.svg" alt="prev"></button>';
+      }
+
+      if (typeof settings.nextArrow === 'undefined') {
+        settings.nextArrow =
+          '<button type="button" class="bw-slick-next"><img src="' +
+          assetsUrl +
+          'img/arrow-d.svg" alt="next"></button>';
+      }
 
       $currentSlider.slick(settings);
 

--- a/bw-main-elementor-widgets.php
+++ b/bw-main-elementor-widgets.php
@@ -88,6 +88,14 @@ function bw_enqueue_flickity() {
         '1.0.0',
         true
     );
+
+    wp_localize_script(
+        'bw-slick-slider-js',
+        'bwSlickSlider',
+        [
+            'assetsUrl' => plugin_dir_url(__FILE__) . 'assets/',
+        ]
+    );
 }
 
 function bw_enqueue_slick_slider_admin_script() {

--- a/includes/widgets/class-bw-slick-slider-widget.php
+++ b/includes/widgets/class-bw-slick-slider-widget.php
@@ -290,6 +290,53 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
 
         $this->end_controls_section();
 
+        $this->start_controls_section(
+            'section_arrows_style',
+            [
+                'label' => __( 'Navigation Arrows', 'bw' ),
+                'tab'   => Controls_Manager::TAB_STYLE,
+            ]
+        );
+
+        $this->add_control(
+            'arrows_color',
+            [
+                'label' => __( 'Arrow Color', 'bw' ),
+                'type'  => Controls_Manager::COLOR,
+                'selectors' => [
+                    '{{WRAPPER}} .bw-slick-prev img, {{WRAPPER}} .bw-slick-next img' => 'filter: brightness(0) saturate(100%) invert(0%) sepia(0%) saturate(0%) hue-rotate(0deg) brightness(0) contrast(100%) drop-shadow(0 0 0 {{VALUE}});',
+                ],
+            ]
+        );
+
+        $this->add_responsive_control(
+            'arrows_size',
+            [
+                'label' => __( 'Arrow Size', 'bw' ),
+                'type' => Controls_Manager::SLIDER,
+                'range' => [
+                    'px' => [ 'min' => 10, 'max' => 100 ],
+                ],
+                'selectors' => [
+                    '{{WRAPPER}} .bw-slick-prev img, {{WRAPPER}} .bw-slick-next img' => 'width: {{SIZE}}{{UNIT}}; height: auto;',
+                ],
+            ]
+        );
+
+        $this->add_responsive_control(
+            'arrows_padding',
+            [
+                'label' => __( 'Arrow Padding', 'bw' ),
+                'type' => Controls_Manager::DIMENSIONS,
+                'size_units' => [ 'px', '%' ],
+                'selectors' => [
+                    '{{WRAPPER}} .bw-slick-prev, {{WRAPPER}} .bw-slick-next' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                ],
+            ]
+        );
+
+        $this->end_controls_section();
+
         $this->start_controls_section( 'images_section', [
             'label' => __( 'Immagini', 'bw-elementor-widgets' ),
         ] );


### PR DESCRIPTION
## Summary
- add Elementor style controls to customize the BW Slick Slider navigation arrows
- load custom arrow markup/assets when initializing the slider and expose asset URLs to the script
- provide base styles and positioning for the custom arrow buttons

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de799fe0a08325860da44468ddd9c0