### PR TITLE
Set default navigation arrow styles for BW Slick Slider

### DIFF
--- a/assets/css/bw-slick-slider.css
+++ b/assets/css/bw-slick-slider.css
@@ -206,10 +206,25 @@
 .bw-slick-next {
   position: absolute;
   bottom: 15px;
-  background: none;
-  border: none;
+  background: none !important;
+  border: none !important;
   cursor: pointer;
   z-index: 10;
+  box-shadow: none !important;
+  padding: 0; /* default */
+}
+
+.bw-slick-prev:hover,
+.bw-slick-next:hover {
+  background: none !important;
+  box-shadow: none !important;
+}
+
+.bw-slick-prev img,
+.bw-slick-next img {
+  width: 30px; /* default */
+  height: auto;
+  display: block;
 }
 
 .bw-slick-prev {

--- a/includes/widgets/class-bw-slick-slider-widget.php
+++ b/includes/widgets/class-bw-slick-slider-widget.php
@@ -317,6 +317,10 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
                 'range' => [
                     'px' => [ 'min' => 10, 'max' => 100 ],
                 ],
+                'default' => [
+                    'size' => 30,
+                    'unit' => 'px',
+                ],
                 'selectors' => [
                     '{{WRAPPER}} .bw-slick-prev img, {{WRAPPER}} .bw-slick-next img' => 'width: {{SIZE}}{{UNIT}}; height: auto;',
                 ],
@@ -329,6 +333,14 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
                 'label' => __( 'Arrow Padding', 'bw' ),
                 'type' => Controls_Manager::DIMENSIONS,
                 'size_units' => [ 'px', '%' ],
+                'default' => [
+                    'top' => 0,
+                    'right' => 0,
+                    'bottom' => 0,
+                    'left' => 0,
+                    'unit' => 'px',
+                    'isLinked' => true,
+                ],
                 'selectors' => [
                     '{{WRAPPER}} .bw-slick-prev, {{WRAPPER}} .bw-slick-next' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
                 ],


### PR DESCRIPTION
## Summary
- set default Elementor control values for slick slider arrow size and padding
- update slick slider arrow styles to enforce default sizing and remove hover backgrounds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de7d84dd948325a6e81cc07b0d50bb