### PR TITLE
Add WooCommerce quick view modal to slick slider widget

### DIFF
--- a/assets/css/bw-slick-slider.css
+++ b/assets/css/bw-slick-slider.css
@@ -202,6 +202,257 @@
   text-decoration: underline;
 }
 
+.bw-quickview-overlay {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  pointer-events: none;
+}
+
+.bw-quickview-overlay.is-active {
+  display: flex;
+  pointer-events: auto;
+}
+
+.bw-quickview-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(7, 7, 10, 0.2);
+  opacity: 0;
+  transition: opacity 0.35s ease;
+}
+
+.bw-quickview-overlay.opening .bw-quickview-backdrop,
+.bw-quickview-overlay.loaded .bw-quickview-backdrop,
+.bw-quickview-overlay.show-content .bw-quickview-backdrop,
+.bw-quickview-overlay.loading .bw-quickview-backdrop {
+  opacity: 1;
+}
+
+.bw-quickview {
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  width: min(90vw, 900px);
+  height: min(90vh, 600px);
+  background: #ffffff;
+  border-radius: 18px;
+  box-shadow: 0 25px 70px rgba(10, 12, 23, 0.25);
+  overflow: hidden;
+  opacity: 0;
+  transform: scale(0.92);
+  transform-origin: center;
+  transition: opacity 0.45s ease, transform 0.45s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.bw-quickview-overlay.opening .bw-quickview,
+.bw-quickview-overlay.loaded .bw-quickview,
+.bw-quickview-overlay.show-content .bw-quickview {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.bw-quickview-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(12, 14, 20, 0.55);
+  color: #ffffff;
+  cursor: pointer;
+  font-size: 1.5rem;
+  line-height: 1;
+  transition: background 0.3s ease;
+  z-index: 2;
+}
+
+.bw-quickview-close:hover,
+.bw-quickview-close:focus {
+  background: rgba(12, 14, 20, 0.75);
+}
+
+.bw-quickview-image {
+  position: relative;
+  flex: 1 1 50%;
+  max-width: 50%;
+  background: #f7f7f9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.bw-quickview-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.5s ease;
+}
+
+.bw-quickview-overlay.show-content .bw-quickview-image img {
+  transform: scale(1.01);
+}
+
+.bw-loader {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 56px;
+  height: 56px;
+  margin: -28px 0 0 -28px;
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+
+.bw-loader::after {
+  content: '';
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 3px solid rgba(0, 0, 0, 0.15);
+  border-top-color: rgba(0, 0, 0, 0.55);
+  animation: bw-spin 0.75s linear infinite;
+}
+
+.bw-quickview-overlay.loading .bw-loader {
+  opacity: 1;
+}
+
+.bw-quickview-content {
+  flex: 1 1 50%;
+  max-width: 50%;
+  background: #ffffff;
+  padding: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  overflow-y: auto;
+  opacity: 0;
+  transform: translateY(35px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+}
+
+.bw-quickview-overlay.show-content .bw-quickview-content {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.bw-qv-title {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.bw-qv-description {
+  color: #54555d;
+}
+
+.bw-qv-price {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #111114;
+}
+
+.bw-qv-addtocart .button,
+.bw-qv-addtocart button,
+.bw-qv-addtocart input[type='submit'] {
+  min-width: 180px;
+  padding: 14px 28px;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.bw-qv-description.is-empty,
+.bw-qv-variations.is-empty,
+.bw-qv-price.is-empty,
+.bw-qv-addtocart.is-empty {
+  display: none;
+}
+
+.bw-qv-message {
+  display: none;
+  margin-top: 12px;
+  font-size: 0.95rem;
+  color: #c13515;
+}
+
+.bw-qv-message.is-visible {
+  display: block;
+}
+
+.bw-quickview-fly-image {
+  border-radius: 18px;
+  pointer-events: none;
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.15);
+}
+
+body.bw-quickview-open {
+  overflow: hidden;
+}
+
+@keyframes bw-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 1024px) {
+  .bw-quickview {
+    flex-direction: column;
+    width: min(92vw, 720px);
+    height: min(95vh, 720px);
+  }
+
+  .bw-quickview-image,
+  .bw-quickview-content {
+    max-width: 100%;
+  }
+
+  .bw-quickview-image {
+    min-height: 45%;
+  }
+
+  .bw-quickview-content {
+    padding: 28px;
+    transform: translateY(25px);
+  }
+}
+
+@media (max-width: 640px) {
+  .bw-quickview {
+    width: 92vw;
+    height: min(96vh, 620px);
+  }
+
+  .bw-quickview-content {
+    padding: 22px;
+    gap: 16px;
+  }
+
+  .bw-quickview-close {
+    top: 12px;
+    right: 12px;
+    width: 32px;
+    height: 32px;
+  }
+}
+
 .bw-slick-prev,
 .bw-slick-next {
   position: absolute;

--- a/assets/js/bw-slick-slider.js
+++ b/assets/js/bw-slick-slider.js
@@ -190,6 +190,362 @@
     return settings;
   };
 
+  var quickViewActiveInstance = null;
+
+  var isObject = function (value) {
+    return Object.prototype.toString.call(value) === '[object Object]';
+  };
+
+  var getLocalizedString = function (key, fallback) {
+    if (
+      isObject(window.bwSlickSlider) &&
+      isObject(window.bwSlickSlider.i18n) &&
+      typeof window.bwSlickSlider.i18n[key] === 'string'
+    ) {
+      return window.bwSlickSlider.i18n[key];
+    }
+
+    return typeof fallback === 'string' ? fallback : '';
+  };
+
+  var fetchQuickViewData = function (productId) {
+    if (!isObject(window.bwSlickSlider) || !window.bwSlickSlider.ajaxUrl) {
+      return $.Deferred().reject({
+        message: 'Missing AJAX endpoint.',
+      }).promise();
+    }
+
+    return $.ajax({
+      url: window.bwSlickSlider.ajaxUrl,
+      type: 'POST',
+      dataType: 'json',
+      data: {
+        action: 'bw_get_quick_view',
+        nonce: window.bwSlickSlider.quickViewNonce || '',
+        product_id: productId,
+      },
+    });
+  };
+
+  var QuickView = function ($widget) {
+    this.$widget = $widget;
+    this.$overlay = $widget.find('[data-product-quick-view]');
+    this.$dialog = this.$overlay.find('.bw-quickview');
+    this.$imageWrap = this.$overlay.find('.bw-quickview-image');
+    this.$image = this.$imageWrap.find('img');
+    this.$loader = this.$overlay.find('.bw-loader');
+    this.$title = this.$overlay.find('.bw-qv-title');
+    this.$description = this.$overlay.find('.bw-qv-description');
+    this.$variations = this.$overlay.find('.bw-qv-variations');
+    this.$price = this.$overlay.find('.bw-qv-price');
+    this.$addToCart = this.$overlay.find('.bw-qv-addtocart');
+    this.$message = this.$overlay.find('.bw-qv-message');
+    this.currentRequest = null;
+    this.isOpen = false;
+    this.isPreparing = false;
+    this.lastTrigger = null;
+
+    this.bindEvents();
+  };
+
+  QuickView.prototype.bindEvents = function () {
+    var self = this;
+
+    this.$widget.on('click', '.overlay-button--quick', function (event) {
+      event.preventDefault();
+
+      var $trigger = $(event.currentTarget);
+      var productId = parseInt($trigger.attr('data-product-id'), 10);
+
+      if (!productId || self.isPreparing) {
+        return;
+      }
+
+      self.open(productId, $trigger);
+    });
+
+    this.$overlay.on('click', '[data-quickview-close]', function (event) {
+      event.preventDefault();
+      self.close();
+    });
+
+    this.$overlay.on('click', function (event) {
+      if (event.target === self.$overlay.get(0)) {
+        self.close();
+      }
+    });
+  };
+
+  QuickView.prototype.animateImage = function ($originImage) {
+    var self = this;
+
+    return new Promise(function (resolve) {
+      if (!$originImage || !$originImage.length || !$originImage.get(0)) {
+        resolve();
+        return;
+      }
+
+      var originRect = $originImage.get(0).getBoundingClientRect();
+
+      if (!originRect.width || !originRect.height) {
+        resolve();
+        return;
+      }
+
+      var $clone = $originImage.clone().addClass('bw-quickview-fly-image');
+      var computed = window.getComputedStyle($originImage.get(0));
+
+      $clone.css({
+        position: 'fixed',
+        top: originRect.top + 'px',
+        left: originRect.left + 'px',
+        width: originRect.width + 'px',
+        height: originRect.height + 'px',
+        margin: 0,
+        zIndex: 99999,
+        transition:
+          'transform 0.55s cubic-bezier(0.23, 1, 0.32, 1), top 0.55s ease, left 0.55s ease, width 0.55s ease, height 0.55s ease',
+        borderRadius: computed.borderRadius || '0px',
+        objectFit: computed.objectFit || 'cover',
+      });
+
+      $('body').append($clone);
+
+      requestAnimationFrame(function () {
+        var targetRect = self.$imageWrap.get(0).getBoundingClientRect();
+        var scaleX = targetRect.width / Math.max(originRect.width, 1);
+        var scaleY = targetRect.height / Math.max(originRect.height, 1);
+        var translateX = targetRect.left - originRect.left;
+        var translateY = targetRect.top - originRect.top;
+
+        $clone.css({
+          transform:
+            'translate3d(' +
+            translateX +
+            'px,' +
+            translateY +
+            'px,0) scale(' +
+            scaleX +
+            ',' +
+            scaleY +
+            ')',
+        });
+      });
+
+      $clone.one('transitionend', function () {
+        $clone.remove();
+        resolve();
+      });
+    });
+  };
+
+  QuickView.prototype.resetContent = function () {
+    this.$title.text('');
+    this.$description.empty();
+    this.$variations.empty();
+    this.$price.empty();
+    this.$addToCart.empty();
+    this.$message.empty().removeClass('is-visible');
+  };
+
+  QuickView.prototype.toggleSection = function ($element, hasContent) {
+    if (!$element || !$element.length) {
+      return;
+    }
+
+    if (hasContent) {
+      $element.removeClass('is-empty').attr('aria-hidden', 'false');
+    } else {
+      $element.addClass('is-empty').attr('aria-hidden', 'true');
+    }
+  };
+
+  QuickView.prototype.showMessage = function (message) {
+    var text = message || getLocalizedString('error', 'Unable to load product.');
+
+    if (this.$message && this.$message.length) {
+      this.$message.text(text).addClass('is-visible');
+    }
+  };
+
+  QuickView.prototype.updateContent = function (data) {
+    var title = data && data.title ? data.title : '';
+    var description = data && data.description ? data.description : '';
+    var priceHtml = data && data.price_html ? data.price_html : '';
+    var variationsHtml = data && data.variations_html ? data.variations_html : '';
+    var addToCartHtml = data && data.add_to_cart_html ? data.add_to_cart_html : '';
+    var imageSrc = data && data.image ? data.image : '';
+    var imageAlt = data && data.image_alt ? data.image_alt : '';
+
+    this.$title.text(title);
+    this.$description.html(description);
+    this.$variations.html(variationsHtml);
+    this.$price.html(priceHtml);
+    this.$addToCart.html(addToCartHtml);
+
+    if (variationsHtml && this.$variations.length && $.fn.wc_variation_form) {
+      this.$variations.find('.variations_form').each(function () {
+        var $form = $(this);
+        if (typeof $form.wc_variation_form === 'function') {
+          $form.wc_variation_form();
+        }
+        $form.trigger('wc_variation_form');
+      });
+    }
+
+    this.toggleSection(this.$description, !!description);
+    this.toggleSection(this.$variations, !!variationsHtml);
+    this.toggleSection(this.$price, !!priceHtml);
+    this.toggleSection(this.$addToCart, !!addToCartHtml);
+
+    if (imageSrc) {
+      this.$image.attr('src', imageSrc);
+    }
+
+    this.$image.attr('alt', imageAlt || title || '');
+  };
+
+  QuickView.prototype.setLoadingState = function (isLoading) {
+    if (isLoading) {
+      this.$overlay.addClass('loading').removeClass('loaded show-content has-error');
+    } else {
+      this.$overlay.removeClass('loading');
+    }
+  };
+
+  QuickView.prototype.open = function (productId, $trigger) {
+    var self = this;
+    var $originImage = null;
+
+    if ($trigger && $trigger.length) {
+      $originImage = $trigger
+        .closest('.bw-ss__card')
+        .find('.bw-ss__media img')
+        .first();
+    }
+
+    this.resetContent();
+    this.isPreparing = true;
+    this.isOpen = true;
+    this.lastTrigger = $trigger || null;
+    quickViewActiveInstance = this;
+
+    this.$overlay.attr('aria-hidden', 'false');
+    this.$overlay.addClass('is-active loading is-preparing');
+    $('body').addClass('bw-quickview-open');
+
+    if ($originImage && $originImage.length) {
+      var previewSrc = $originImage.attr('src') || $originImage.attr('data-src') || '';
+      var previewAlt = $originImage.attr('alt') || '';
+      if (previewSrc) {
+        this.$image.attr('src', previewSrc);
+      }
+      this.$image.attr('alt', previewAlt);
+    }
+
+    this.animateImage($originImage).then(function () {
+      self.$overlay.removeClass('is-preparing').addClass('opening');
+      self.$dialog.focus();
+    });
+
+    this.setLoadingState(true);
+
+    this.fetchData(productId)
+      .then(function (data) {
+        if (!self.isOpen) {
+          return;
+        }
+        self.updateContent(data || {});
+        self.$overlay.addClass('loaded');
+        setTimeout(function () {
+          self.$overlay.addClass('show-content');
+        }, 40);
+      })
+      .catch(function (error) {
+        if (!self.isOpen) {
+          return;
+        }
+        var message = error && error.message ? error.message : null;
+        self.$overlay.addClass('has-error loaded show-content');
+        self.showMessage(message);
+      })
+      .then(function () {
+        if (!self.isOpen) {
+          return;
+        }
+        self.setLoadingState(false);
+        self.isPreparing = false;
+      });
+  };
+
+  QuickView.prototype.fetchData = function (productId) {
+    var self = this;
+
+    if (this.currentRequest && typeof this.currentRequest.abort === 'function') {
+      this.currentRequest.abort();
+    }
+
+    return new Promise(function (resolve, reject) {
+      self.currentRequest = fetchQuickViewData(productId)
+        .done(function (response) {
+          if (response && response.success) {
+            resolve(response.data || {});
+          } else {
+            var message = getLocalizedString('error', 'Unable to load product.');
+            if (response && response.data && response.data.message) {
+              message = response.data.message;
+            }
+            reject({ message: message });
+          }
+        })
+        .fail(function (jqXHR) {
+          var errorMessage = getLocalizedString('error', 'Unable to load product.');
+
+          if (jqXHR && jqXHR.responseJSON && jqXHR.responseJSON.data) {
+            if (jqXHR.responseJSON.data.message) {
+              errorMessage = jqXHR.responseJSON.data.message;
+            }
+          }
+
+          reject({ message: errorMessage });
+        })
+        .always(function () {
+          self.currentRequest = null;
+        });
+    });
+  };
+
+  QuickView.prototype.close = function () {
+    if (!this.isOpen) {
+      return;
+    }
+
+    var $lastTrigger = this.lastTrigger;
+
+    if (this.currentRequest && typeof this.currentRequest.abort === 'function') {
+      this.currentRequest.abort();
+      this.currentRequest = null;
+    }
+
+    this.isOpen = false;
+    this.isPreparing = false;
+    this.lastTrigger = null;
+
+    this.$overlay
+      .removeClass('is-active opening loaded show-content loading has-error is-preparing')
+      .attr('aria-hidden', 'true');
+
+    $('body').removeClass('bw-quickview-open');
+
+    if ($lastTrigger && $lastTrigger.length) {
+      $lastTrigger.focus();
+    }
+
+    if (quickViewActiveInstance === this) {
+      quickViewActiveInstance = null;
+    }
+  };
+
   var initSlickSlider = function ($scope) {
     var $slider = $scope.find('.bw-slick-slider');
 
@@ -235,6 +591,32 @@
     });
   };
 
+  var initQuickView = function ($scope) {
+    var $widget = $scope.closest('.elementor-widget-bw-slick-slider');
+
+    if (!$widget.length) {
+      $widget = $scope;
+    }
+
+    if ($widget.data('bwQuickViewInit')) {
+      return;
+    }
+
+    if (!$widget.find('[data-product-quick-view]').length) {
+      return;
+    }
+
+    $widget.data('bwQuickViewInit', true);
+    var instance = new QuickView($widget);
+    $widget.data('bwQuickViewInstance', instance);
+  };
+
+  $(document).on('keyup', function (event) {
+    if (event.key === 'Escape' && quickViewActiveInstance) {
+      quickViewActiveInstance.close();
+    }
+  });
+
   $(window).on('elementor/frontend/init', function () {
     if (
       typeof elementorFrontend === 'undefined' ||
@@ -248,6 +630,7 @@
       'frontend/element_ready/bw-slick-slider.default',
       function ($scope) {
         initSlickSlider($scope);
+        initQuickView($scope);
       }
     );
   });

--- a/bw-main-elementor-widgets.php
+++ b/bw-main-elementor-widgets.php
@@ -89,11 +89,21 @@ function bw_enqueue_flickity() {
         true
     );
 
+    if ( class_exists( 'WooCommerce' ) ) {
+        wp_enqueue_script( 'wc-add-to-cart-variation' );
+    }
+
     wp_localize_script(
         'bw-slick-slider-js',
         'bwSlickSlider',
         [
             'assetsUrl' => plugin_dir_url(__FILE__) . 'assets/',
+            'ajaxUrl'   => admin_url( 'admin-ajax.php' ),
+            'quickViewNonce' => wp_create_nonce( 'bw_quick_view_nonce' ),
+            'i18n'      => [
+                'loading' => __( 'Caricamento prodotto…', 'bw' ),
+                'error'   => __( 'Impossibile caricare le informazioni del prodotto.', 'bw' ),
+            ],
         ]
     );
 }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -72,3 +72,147 @@ if ( ! function_exists( 'bw_ajax_get_child_categories' ) ) {
 }
 
 add_action( 'wp_ajax_bw_get_child_categories', 'bw_ajax_get_child_categories' );
+add_action( 'wp_ajax_bw_get_quick_view', 'bw_ajax_get_quick_view_product' );
+add_action( 'wp_ajax_nopriv_bw_get_quick_view', 'bw_ajax_get_quick_view_product' );
+
+if ( ! function_exists( 'bw_get_quick_view_add_to_cart_html' ) ) {
+    /**
+     * Capture the WooCommerce add to cart form markup for a given product.
+     *
+     * @param \WC_Product $product WooCommerce product instance.
+     *
+     * @return string
+     */
+    function bw_get_quick_view_add_to_cart_html( $wc_product ) {
+        if ( ! $wc_product instanceof \WC_Product ) {
+            return '';
+        }
+
+        global $product, $post;
+
+        $previous_product = isset( $product ) ? $product : null;
+        $previous_post    = isset( $post ) ? $post : null;
+        $post_object      = get_post( $wc_product->get_id() );
+
+        if ( $post_object instanceof \WP_Post ) {
+            $post = $post_object; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+            setup_postdata( $post );
+        }
+
+        $product = $wc_product; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+
+        ob_start();
+
+        if ( $wc_product->is_type( 'variable' ) && function_exists( 'woocommerce_variable_add_to_cart' ) ) {
+            woocommerce_variable_add_to_cart();
+        } elseif ( $wc_product->is_type( 'grouped' ) && function_exists( 'woocommerce_grouped_add_to_cart' ) ) {
+            woocommerce_grouped_add_to_cart();
+        } elseif ( $wc_product->is_type( 'external' ) && function_exists( 'woocommerce_external_add_to_cart' ) ) {
+            woocommerce_external_add_to_cart();
+        } elseif ( function_exists( 'woocommerce_simple_add_to_cart' ) ) {
+            woocommerce_simple_add_to_cart();
+        }
+
+        $html = ob_get_clean();
+
+        if ( $post_object instanceof \WP_Post ) {
+            wp_reset_postdata();
+        }
+
+        if ( $previous_product instanceof \WC_Product ) {
+            $product = $previous_product; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+        } else {
+            unset( $product );
+        }
+
+        if ( $previous_post instanceof \WP_Post ) {
+            $post = $previous_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+        }
+
+        return $html;
+    }
+}
+
+if ( ! function_exists( 'bw_ajax_get_quick_view_product' ) ) {
+    /**
+     * AJAX callback to retrieve WooCommerce product information for Quick View.
+     */
+    function bw_ajax_get_quick_view_product() {
+        check_ajax_referer( 'bw_quick_view_nonce', 'nonce' );
+
+        $product_id = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
+
+        if ( $product_id <= 0 ) {
+            wp_send_json_error(
+                [ 'message' => __( 'Prodotto non valido.', 'bw' ) ],
+                400
+            );
+        }
+
+        if ( ! function_exists( 'wc_get_product' ) ) {
+            wp_send_json_error(
+                [ 'message' => __( 'WooCommerce non è attivo.', 'bw' ) ],
+                400
+            );
+        }
+
+        $product = wc_get_product( $product_id );
+
+        if ( ! $product ) {
+            wp_send_json_error(
+                [ 'message' => __( 'Prodotto non trovato.', 'bw' ) ],
+                404
+            );
+        }
+
+        $image_id  = $product->get_image_id();
+        $image_url = '';
+        $image_alt = '';
+
+        if ( $image_id ) {
+            $image_url = wp_get_attachment_image_url( $image_id, 'large' );
+            $image_alt = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
+        }
+
+        if ( empty( $image_url ) && function_exists( 'wc_placeholder_img_src' ) ) {
+            $image_url = wc_placeholder_img_src();
+        }
+
+        $description = $product->get_short_description();
+
+        if ( empty( $description ) ) {
+            $description = $product->get_description();
+        }
+
+        if ( function_exists( 'wc_format_content' ) ) {
+            $description = wc_format_content( $description );
+        } else {
+            $description = wpautop( do_shortcode( $description ) );
+        }
+
+        $price_html = $product->get_price_html();
+        $cart_html  = bw_get_quick_view_add_to_cart_html( $product );
+
+        $variations_html = '';
+        $add_to_cart_html = $cart_html;
+
+        if ( $product->is_type( 'variable' ) ) {
+            $variations_html  = $cart_html;
+            $add_to_cart_html = '';
+        }
+
+        $data = [
+            'id'              => $product_id,
+            'title'           => $product->get_name(),
+            'image'           => $image_url,
+            'image_alt'       => $image_alt,
+            'description'     => $description,
+            'price_html'      => $price_html,
+            'variations_html' => $variations_html,
+            'add_to_cart_html'=> $add_to_cart_html,
+            'permalink'       => get_permalink( $product_id ),
+        ];
+
+        wp_send_json_success( $data );
+    }
+}

--- a/includes/widgets/class-bw-slick-slider-widget.php
+++ b/includes/widgets/class-bw-slick-slider-widget.php
@@ -179,6 +179,30 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
 
         $this->end_controls_section();
 
+        $this->start_controls_section(
+            'section_quick_view',
+            [
+                'label'     => __( 'Quick View', 'bw' ),
+                'tab'       => Controls_Manager::TAB_CONTENT,
+                'condition' => [ 'content_type' => 'product' ],
+            ]
+        );
+
+        $this->add_control(
+            'quick_view_enable',
+            [
+                'label'        => __( 'Enable Quick View', 'bw' ),
+                'type'         => Controls_Manager::SWITCHER,
+                'label_on'     => __( 'On', 'bw' ),
+                'label_off'    => __( 'Off', 'bw' ),
+                'return_value' => 'yes',
+                'default'      => 'yes',
+                'description'  => __( 'Mostra il pulsante Quick View sul prodotto.', 'bw' ),
+            ]
+        );
+
+        $this->end_controls_section();
+
         $this->start_controls_section( 'typography_section', [
             'label' => __( 'Typography', 'bw-elementor-widgets' ),
             'tab'   => Controls_Manager::TAB_STYLE,
@@ -287,6 +311,59 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
                 '{{WRAPPER}} .bw-slick-slider .bw-slick-price' => 'margin-bottom: {{SIZE}}{{UNIT}};',
             ],
         ] );
+
+        $this->end_controls_section();
+
+        $this->start_controls_section(
+            'section_quickview_style',
+            [
+                'label'     => __( 'Quick View', 'bw' ),
+                'tab'       => Controls_Manager::TAB_STYLE,
+                'condition' => [
+                    'content_type'      => 'product',
+                    'quick_view_enable' => 'yes',
+                ],
+            ]
+        );
+
+        $this->add_group_control(
+            Group_Control_Typography::get_type(),
+            [
+                'name'     => 'qv_title_typo',
+                'label'    => __( 'Title Typography', 'bw' ),
+                'selector' => '{{WRAPPER}} .bw-quickview .bw-qv-title',
+            ]
+        );
+
+        $this->add_group_control(
+            Group_Control_Typography::get_type(),
+            [
+                'name'     => 'qv_desc_typo',
+                'label'    => __( 'Description Typography', 'bw' ),
+                'selector' => '{{WRAPPER}} .bw-quickview .bw-qv-description',
+            ]
+        );
+
+        $this->add_group_control(
+            Group_Control_Typography::get_type(),
+            [
+                'name'     => 'qv_price_typo',
+                'label'    => __( 'Price Typography', 'bw' ),
+                'selector' => '{{WRAPPER}} .bw-quickview .bw-qv-price',
+            ]
+        );
+
+        $this->add_responsive_control(
+            'qv_padding',
+            [
+                'label'      => __( 'Content Padding', 'bw' ),
+                'type'       => Controls_Manager::DIMENSIONS,
+                'size_units' => [ 'px', '%' ],
+                'selectors'  => [
+                    '{{WRAPPER}} .bw-quickview .bw-quickview-content' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                ],
+            ]
+        );
 
         $this->end_controls_section();
 
@@ -692,6 +769,8 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
             ? ( 'yes' === $settings['view_buttons_enable'] )
             : ( isset( $settings['overlay_buttons_enable'] ) ? 'yes' === $settings['overlay_buttons_enable'] : true );
         $content_type  = isset( $settings['content_type'] ) && 'product' === $settings['content_type'] ? 'product' : 'post';
+        $quick_view_setting = isset( $settings['quick_view_enable'] ) ? ( 'yes' === $settings['quick_view_enable'] ) : true;
+        $quick_view_enabled = ( 'product' === $content_type ) && $quick_view_setting;
         $columns       = isset( $settings['columns'] ) ? max( 1, absint( $settings['columns'] ) ) : 3;
         $gap           = isset( $settings['gap']['size'] ) ? max( 0, absint( $settings['gap']['size'] ) ) : 24;
         $image_height  = isset( $settings['image_height'] ) ? max( 0, absint( $settings['image_height'] ) ) : 0;
@@ -751,6 +830,9 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
         $slider_settings = $this->prepare_slider_settings( $settings, $columns, $slides_scroll );
 
         $wrapper_classes = [ 'bw-slick-slider' ];
+        if ( $quick_view_enabled && 'product' === $content_type ) {
+            $wrapper_classes[] = 'bw-slick-slider--quick-view';
+        }
         if ( ! $image_crop ) {
             $wrapper_classes[] = 'bw-slick-slider--no-crop';
         }
@@ -773,6 +855,7 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
         <div
             class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $wrapper_classes ) ) ); ?>"
             data-columns="<?php echo esc_attr( $columns ); ?>"
+            data-has-quick-view="<?php echo $quick_view_enabled ? 'true' : 'false'; ?>"
             <?php if ( $slider_settings_json ) : ?>
                 data-slider-settings="<?php echo $slider_settings_json; ?>"
             <?php endif; ?>
@@ -825,13 +908,21 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
                                 <?php else : ?>
                                     <span class="bw-slick-item__image-placeholder" aria-hidden="true"></span>
                                 <?php endif; ?>
-                                <?php if ( $thumbnail_html && $view_buttons_enabled ) : ?>
+                                <?php if ( $thumbnail_html && $view_buttons_enabled && ! $quick_view_enabled ) : ?>
                                     <div class="overlay-buttons bw-ss__overlay has-buttons">
                                         <div class="bw-ss__buttons">
                                             <a class="overlay-button overlay-button--view bw-ss__btn" href="<?php echo esc_url( $permalink ); ?>">
                                                 <span class="overlay-button__label"><?php esc_html_e( 'View Product', 'bw-elementor-widgets' ); ?></span>
                                             </a>
-                                            <a class="overlay-button overlay-button--quick bw-ss__btn" href="<?php echo esc_url( $quick_view_link ); ?>">
+                                        </div>
+                                    </div>
+                                <?php elseif ( $thumbnail_html && $view_buttons_enabled && $quick_view_enabled ) : ?>
+                                    <div class="overlay-buttons bw-ss__overlay has-buttons">
+                                        <div class="bw-ss__buttons">
+                                            <a class="overlay-button overlay-button--view bw-ss__btn" href="<?php echo esc_url( $permalink ); ?>">
+                                                <span class="overlay-button__label"><?php esc_html_e( 'View Product', 'bw-elementor-widgets' ); ?></span>
+                                            </a>
+                                            <a class="overlay-button overlay-button--quick bw-ss__btn" href="<?php echo esc_url( $quick_view_link ); ?>" data-product-id="<?php echo esc_attr( $post_id ); ?>">
                                                 <span class="overlay-button__label"><?php esc_html_e( 'Quick View', 'bw-elementor-widgets' ); ?></span>
                                             </a>
                                         </div>
@@ -865,6 +956,28 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
                 </div>
             <?php endif; ?>
         </div>
+        <?php if ( $quick_view_enabled && 'product' === $content_type ) : ?>
+            <div class="bw-quickview-overlay" data-product-quick-view aria-hidden="true">
+                <div class="bw-quickview-backdrop" data-quickview-close></div>
+                <div class="bw-quickview" role="dialog" aria-modal="true" aria-label="<?php esc_attr_e( 'Product quick view', 'bw-elementor-widgets' ); ?>" tabindex="-1">
+                    <button type="button" class="bw-quickview-close" aria-label="<?php esc_attr_e( 'Close quick view', 'bw-elementor-widgets' ); ?>" data-quickview-close>
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                    <div class="bw-quickview-image">
+                        <img src="" alt="" />
+                        <div class="bw-loader" aria-hidden="true"></div>
+                    </div>
+                    <div class="bw-quickview-content">
+                        <h2 class="bw-qv-title">Product Title</h2>
+                        <div class="bw-qv-description">Product short description</div>
+                        <div class="bw-qv-variations"></div>
+                        <div class="bw-qv-price">$99.00</div>
+                        <div class="bw-qv-addtocart"></div>
+                        <div class="bw-qv-message" role="alert"></div>
+                    </div>
+                </div>
+            </div>
+        <?php endif; ?>
         <?php
         wp_reset_postdata();
     }


### PR DESCRIPTION
## Summary
- add Elementor quick view controls and render the modal template for product cards in the slick slider widget
- expose an AJAX endpoint to return WooCommerce product details and pass the configuration to the front end
- build the quick view animation, loader handling, and responsive styling for the lightbox experience

## Testing
- php -l includes/widgets/class-bw-slick-slider-widget.php
- php -l includes/helpers.php
- php -l bw-main-elementor-widgets.php

------
https://chatgpt.com/codex/tasks/task_e_68dea11bd0d4832583e69d49a42d89e4