### PR TITLE
Refactor slick slider quick view handling

### DIFF
--- a/assets/css/bw-slick-slider.css
+++ b/assets/css/bw-slick-slider.css
@@ -85,6 +85,7 @@
 }
 
 .bw-slick-slider .overlay-buttons,
+.bw-slick-slider .bw-overlay-buttons,
 .bw-slick-slider .bw-ss__overlay {
   position: absolute;
   inset: 0;
@@ -117,7 +118,8 @@
   pointer-events: auto;
 }
 
-.bw-slick-slider .overlay-button {
+.bw-slick-slider .overlay-button,
+.bw-slick-slider .bw-overlay-button {
   position: relative;
   display: inline-flex;
   justify-content: center;
@@ -208,33 +210,36 @@
   text-decoration: underline;
 }
 
+
 .bw-quickview-overlay {
   position: fixed;
   inset: 0;
-  display: none;
+  display: flex;
   align-items: center;
   justify-content: center;
+  padding: 24px;
   z-index: 9999;
+  opacity: 0;
+  visibility: hidden;
   pointer-events: none;
+  transition: opacity 0.35s ease, visibility 0.35s ease;
 }
 
-.bw-quickview-overlay.is-active {
-  display: flex;
+.bw-quickview-overlay.active {
+  opacity: 1;
+  visibility: visible;
   pointer-events: auto;
 }
 
 .bw-quickview-backdrop {
   position: absolute;
   inset: 0;
-  background: rgba(7, 7, 10, 0.2);
+  background: rgba(7, 7, 10, 0.3);
   opacity: 0;
   transition: opacity 0.35s ease;
 }
 
-.bw-quickview-overlay.opening .bw-quickview-backdrop,
-.bw-quickview-overlay.loaded .bw-quickview-backdrop,
-.bw-quickview-overlay.show-content .bw-quickview-backdrop,
-.bw-quickview-overlay.loading .bw-quickview-backdrop {
+.bw-quickview-backdrop.visible {
   opacity: 1;
 }
 
@@ -249,14 +254,14 @@
   box-shadow: 0 25px 70px rgba(10, 12, 23, 0.25);
   overflow: hidden;
   opacity: 0;
-  transform: scale(0.92);
+  transform: scale(0.94);
   transform-origin: center;
-  transition: opacity 0.45s ease, transform 0.45s cubic-bezier(0.23, 1, 0.32, 1);
+  transition: opacity 0.4s ease, transform 0.4s ease;
 }
 
-.bw-quickview-overlay.opening .bw-quickview,
-.bw-quickview-overlay.loaded .bw-quickview,
-.bw-quickview-overlay.show-content .bw-quickview {
+.bw-quickview.opening,
+.bw-quickview.loaded,
+.bw-quickview.show-content {
   opacity: 1;
   transform: scale(1);
 }
@@ -301,11 +306,6 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
-  transition: transform 0.5s ease;
-}
-
-.bw-quickview-overlay.show-content .bw-quickview-image img {
-  transform: scale(1.01);
 }
 
 .bw-loader {
@@ -334,7 +334,7 @@
   animation: bw-spin 0.75s linear infinite;
 }
 
-.bw-quickview-overlay.loading .bw-loader {
+.bw-quickview.loading .bw-loader {
   opacity: 1;
 }
 
@@ -348,11 +348,11 @@
   gap: 20px;
   overflow-y: auto;
   opacity: 0;
-  transform: translateY(35px);
+  transform: translateY(40px);
   transition: opacity 0.4s ease, transform 0.4s ease;
 }
 
-.bw-quickview-overlay.show-content .bw-quickview-content {
+.bw-quickview.show-content .bw-quickview-content {
   opacity: 1;
   transform: translateY(0);
 }
@@ -397,12 +397,6 @@
 
 .bw-qv-message.is-visible {
   display: block;
-}
-
-.bw-quickview-fly-image {
-  border-radius: 18px;
-  pointer-events: none;
-  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.15);
 }
 
 body.bw-quickview-open {

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -74,6 +74,8 @@ if ( ! function_exists( 'bw_ajax_get_child_categories' ) ) {
 add_action( 'wp_ajax_bw_get_child_categories', 'bw_ajax_get_child_categories' );
 add_action( 'wp_ajax_bw_get_quick_view', 'bw_ajax_get_quick_view_product' );
 add_action( 'wp_ajax_nopriv_bw_get_quick_view', 'bw_ajax_get_quick_view_product' );
+add_action( 'wp_ajax_bw_quickview_product', 'bw_ajax_quickview_product' );
+add_action( 'wp_ajax_nopriv_bw_quickview_product', 'bw_ajax_quickview_product' );
 
 if ( ! function_exists( 'bw_get_quick_view_add_to_cart_html' ) ) {
     /**
@@ -133,35 +135,38 @@ if ( ! function_exists( 'bw_get_quick_view_add_to_cart_html' ) ) {
     }
 }
 
-if ( ! function_exists( 'bw_ajax_get_quick_view_product' ) ) {
+if ( ! function_exists( 'bw_get_quick_view_product_data' ) ) {
     /**
-     * AJAX callback to retrieve WooCommerce product information for Quick View.
+     * Build the data array for the Quick View response.
+     *
+     * @param int $product_id WooCommerce product ID.
+     *
+     * @return array|\WP_Error
      */
-    function bw_ajax_get_quick_view_product() {
-        check_ajax_referer( 'bw_quick_view_nonce', 'nonce' );
-
-        $product_id = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
-
+    function bw_get_quick_view_product_data( $product_id ) {
         if ( $product_id <= 0 ) {
-            wp_send_json_error(
-                [ 'message' => __( 'Prodotto non valido.', 'bw' ) ],
-                400
+            return new \WP_Error(
+                'bw_quick_view_invalid_product',
+                __( 'Prodotto non valido.', 'bw' ),
+                [ 'status' => 400 ]
             );
         }
 
         if ( ! function_exists( 'wc_get_product' ) ) {
-            wp_send_json_error(
-                [ 'message' => __( 'WooCommerce non è attivo.', 'bw' ) ],
-                400
+            return new \WP_Error(
+                'bw_quick_view_missing_wc',
+                __( 'WooCommerce non è attivo.', 'bw' ),
+                [ 'status' => 400 ]
             );
         }
 
         $product = wc_get_product( $product_id );
 
         if ( ! $product ) {
-            wp_send_json_error(
-                [ 'message' => __( 'Prodotto non trovato.', 'bw' ) ],
-                404
+            return new \WP_Error(
+                'bw_quick_view_not_found',
+                __( 'Prodotto non trovato.', 'bw' ),
+                [ 'status' => 404 ]
             );
         }
 
@@ -193,7 +198,7 @@ if ( ! function_exists( 'bw_ajax_get_quick_view_product' ) ) {
         $price_html = $product->get_price_html();
         $cart_html  = bw_get_quick_view_add_to_cart_html( $product );
 
-        $variations_html = '';
+        $variations_html  = '';
         $add_to_cart_html = $cart_html;
 
         if ( $product->is_type( 'variable' ) ) {
@@ -201,18 +206,75 @@ if ( ! function_exists( 'bw_ajax_get_quick_view_product' ) ) {
             $add_to_cart_html = '';
         }
 
-        $data = [
-            'id'              => $product_id,
-            'title'           => $product->get_name(),
-            'image'           => $image_url,
-            'image_alt'       => $image_alt,
-            'description'     => $description,
-            'price_html'      => $price_html,
-            'variations_html' => $variations_html,
-            'add_to_cart_html'=> $add_to_cart_html,
-            'permalink'       => get_permalink( $product_id ),
+        return [
+            'id'               => $product_id,
+            'title'            => $product->get_name(),
+            'image'            => $image_url,
+            'image_alt'        => $image_alt,
+            'description'      => $description,
+            'price'            => $price_html,
+            'price_html'       => $price_html,
+            'variations'       => $variations_html,
+            'variations_html'  => $variations_html,
+            'add_to_cart'      => $add_to_cart_html,
+            'add_to_cart_html' => $add_to_cart_html,
+            'permalink'        => get_permalink( $product_id ),
         ];
+    }
+}
+
+if ( ! function_exists( 'bw_send_quick_view_response' ) ) {
+    /**
+     * Send the Quick View response payload.
+     *
+     * @param int $product_id WooCommerce product ID.
+     */
+    function bw_send_quick_view_response( $product_id ) {
+        $data = bw_get_quick_view_product_data( $product_id );
+
+        if ( is_wp_error( $data ) ) {
+            $status = 400;
+            $error_data = $data->get_error_data();
+
+            if ( is_array( $error_data ) && isset( $error_data['status'] ) ) {
+                $status_candidate = absint( $error_data['status'] );
+                if ( $status_candidate > 0 ) {
+                    $status = $status_candidate;
+                }
+            }
+
+            wp_send_json_error(
+                [ 'message' => $data->get_error_message() ],
+                $status
+            );
+        }
 
         wp_send_json_success( $data );
+    }
+}
+
+if ( ! function_exists( 'bw_ajax_get_quick_view_product' ) ) {
+    /**
+     * AJAX callback to retrieve WooCommerce product information for legacy Quick View action.
+     */
+    function bw_ajax_get_quick_view_product() {
+        check_ajax_referer( 'bw_quick_view_nonce', 'nonce' );
+
+        $product_id = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
+
+        bw_send_quick_view_response( $product_id );
+    }
+}
+
+if ( ! function_exists( 'bw_ajax_quickview_product' ) ) {
+    /**
+     * AJAX callback used by the Slick Slider Quick View popup.
+     */
+    function bw_ajax_quickview_product() {
+        check_ajax_referer( 'bw_quick_view_nonce', 'nonce' );
+
+        $product_id = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
+
+        bw_send_quick_view_response( $product_id );
     }
 }

--- a/includes/widgets/class-bw-slick-slider-widget.php
+++ b/includes/widgets/class-bw-slick-slider-widget.php
@@ -890,7 +890,6 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
                         $price_html = $this->get_price_markup( $post_id );
                     }
 
-                    $quick_view_link = add_query_arg( [ 'quick-view' => $post_id ], $permalink );
                     ?>
                     <article <?php post_class( 'bw-slick-item' ); ?>>
                         <div class="bw-slick-item__inner bw-ss__card">
@@ -909,20 +908,20 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
                                     <span class="bw-slick-item__image-placeholder" aria-hidden="true"></span>
                                 <?php endif; ?>
                                 <?php if ( $thumbnail_html && $view_buttons_enabled && ! $quick_view_enabled ) : ?>
-                                    <div class="overlay-buttons bw-ss__overlay has-buttons">
+                                    <div class="overlay-buttons bw-overlay-buttons bw-ss__overlay has-buttons">
                                         <div class="bw-ss__buttons">
-                                            <a class="overlay-button overlay-button--view bw-ss__btn bw-view-btn" href="<?php echo esc_url( $permalink ); ?>">
+                                            <a class="overlay-button bw-overlay-button overlay-button--view bw-ss__btn bw-view-btn" href="<?php echo esc_url( $permalink ); ?>">
                                                 <span class="overlay-button__label"><?php esc_html_e( 'View Product', 'bw-elementor-widgets' ); ?></span>
                                             </a>
                                         </div>
                                     </div>
                                 <?php elseif ( $thumbnail_html && $view_buttons_enabled && $quick_view_enabled ) : ?>
-                                    <div class="overlay-buttons bw-ss__overlay has-buttons">
+                                    <div class="overlay-buttons bw-overlay-buttons bw-ss__overlay has-buttons">
                                         <div class="bw-ss__buttons">
-                                            <a class="overlay-button overlay-button--view bw-ss__btn bw-view-btn" href="<?php echo esc_url( $permalink ); ?>">
+                                            <a class="overlay-button bw-overlay-button overlay-button--view bw-ss__btn bw-view-btn" href="<?php echo esc_url( $permalink ); ?>">
                                                 <span class="overlay-button__label"><?php esc_html_e( 'View Product', 'bw-elementor-widgets' ); ?></span>
                                             </a>
-                                            <a class="overlay-button overlay-button--quick bw-ss__btn bw-quickview-btn" href="<?php echo esc_url( $quick_view_link ); ?>" data-product-id="<?php echo esc_attr( $post_id ); ?>">
+                                            <a class="overlay-button bw-overlay-button overlay-button--quick bw-ss__btn bw-quickview-btn bw-qv-btn" href="#" data-product-id="<?php echo esc_attr( $post_id ); ?>">
                                                 <span class="overlay-button__label"><?php esc_html_e( 'Quick View', 'bw-elementor-widgets' ); ?></span>
                                             </a>
                                         </div>
@@ -960,7 +959,7 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
             <div class="bw-quickview-overlay" data-product-quick-view aria-hidden="true">
                 <div class="bw-quickview-backdrop" data-quickview-close></div>
                 <div class="bw-quickview" role="dialog" aria-modal="true" aria-label="<?php esc_attr_e( 'Product quick view', 'bw-elementor-widgets' ); ?>" tabindex="-1">
-                    <button type="button" class="bw-quickview-close" aria-label="<?php esc_attr_e( 'Close quick view', 'bw-elementor-widgets' ); ?>" data-quickview-close>
+                    <button type="button" class="bw-quickview-close bw-qv-close" aria-label="<?php esc_attr_e( 'Close quick view', 'bw-elementor-widgets' ); ?>" data-quickview-close>
                         <span aria-hidden="true">&times;</span>
                     </button>
                     <div class="bw-quickview-image">


### PR DESCRIPTION
## Summary
- refactor the quick view JavaScript to initialise in Elementor, load WooCommerce data over AJAX, and manage the popup class state
- restyle the quick view overlay to remove the fly-in image animation and introduce fade/translate transitions with a loader
- update widget markup and helpers so the overlay buttons stay paired with a new AJAX endpoint that returns product content

## Testing
- php -l includes/helpers.php

------
https://chatgpt.com/codex/tasks/task_e_68deb35b00788325887fc7b8ca7254f6