### PR TITLE
Bust cache for slick slider script

### DIFF
--- a/bw-main-elementor-widgets.php
+++ b/bw-main-elementor-widgets.php
@@ -85,7 +85,7 @@ function bw_enqueue_flickity() {
         'bw-slick-slider-js',
         plugin_dir_url(__FILE__) . 'assets/js/bw-slick-slider.js',
         ['jquery', 'slick-js'],
-        '1.0.0',
+        filemtime( __DIR__ . '/assets/js/bw-slick-slider.js' ),
         true
     );
 


### PR DESCRIPTION
## Summary
- bust the Elementor slick slider script cache by using `filemtime` as the version argument

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df6cf3bf848325946ea4cb920d4939