### PR TITLE
Improve quick view AJAX configuration handling

### DIFF
--- a/includes/widgets/class-bw-slick-slider-widget.php
+++ b/includes/widgets/class-bw-slick-slider-widget.php
@@ -957,7 +957,7 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
             <?php endif; ?>
         </div>
         <?php if ( $quick_view_enabled && 'product' === $content_type ) : ?>
-            <div class="bw-quickview-overlay" data-product-quick-view aria-hidden="true">
+            <div class="bw-quickview-overlay" data-product-quick-view aria-hidden="true" data-ajax-url="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>" data-quick-view-nonce="<?php echo esc_attr( wp_create_nonce( 'bw_quick_view_nonce' ) ); ?>">
                 <div class="bw-quickview-backdrop" data-quickview-close></div>
                 <div class="bw-quickview" role="dialog" aria-modal="true" aria-label="<?php esc_attr_e( 'Product quick view', 'bw-elementor-widgets' ); ?>" tabindex="-1">
                     <button type="button" class="bw-quickview-close" aria-label="<?php esc_attr_e( 'Close quick view', 'bw-elementor-widgets' ); ?>" data-quickview-close>


### PR DESCRIPTION
## Summary
- ensure quick view fetch logic pulls the AJAX endpoint and nonce from overlay datasets with fallbacks to global Elementor/WordPress values
- pass overlay-specific configuration into the quick view modal initializer and expose matching data attributes in the widget markup

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dfa4f21a7c83259a33c05843d06df0