### PR TITLE
Add direct Add to Cart button to BW Slick Slider products

### DIFF
--- a/assets/css/bw-slick-slider.css
+++ b/assets/css/bw-slick-slider.css
@@ -122,7 +122,8 @@
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  width: 50%;
+  width: 100%;
+  flex: 1 1 100%;
   padding: var(--bw-overlay-buttons-padding-y) var(--bw-overlay-buttons-padding-x);
   background: var(--bw-overlay-buttons-background);
   color: var(--bw-overlay-buttons-color);
@@ -134,9 +135,13 @@
   transition: background 0.3s ease, color 0.3s ease;
 }
 
-.bw-slick-slider .bw-ss__buttons .bw-view-btn {
-  flex: 1 1 100%;
-  width: 100%;
+.bw-slick-slider .bw-ss__buttons--double .overlay-button {
+  flex: 1 1 50%;
+  width: 50%;
+}
+
+.bw-slick-slider .bw-btn-addtocart {
+  text-decoration: none;
 }
 
 .bw-slick-slider .overlay-button:first-child {

--- a/includes/widgets/class-bw-slick-slider-widget.php
+++ b/includes/widgets/class-bw-slick-slider-widget.php
@@ -803,8 +803,32 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
                     }
 
                     $price_html = '';
+                    $has_add_to_cart = false;
+                    $add_to_cart_url = '';
                     if ( 'product' === $content_type ) {
                         $price_html = $this->get_price_markup( $post_id );
+
+                        if ( function_exists( 'wc_get_product' ) ) {
+                            $product = wc_get_product( $post_id );
+
+                            if ( $product ) {
+                                if ( $product->is_type( 'variable' ) ) {
+                                    $add_to_cart_url = $permalink;
+                                } else {
+                                    $cart_url = function_exists( 'wc_get_cart_url' ) ? wc_get_cart_url() : '';
+
+                                    if ( $cart_url ) {
+                                        $add_to_cart_url = add_query_arg( 'add-to-cart', $product->get_id(), $cart_url );
+                                    }
+                                }
+
+                                if ( ! $add_to_cart_url ) {
+                                    $add_to_cart_url = $permalink;
+                                }
+
+                                $has_add_to_cart = true;
+                            }
+                        }
                     }
 
                     ?>
@@ -826,10 +850,15 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
                                 <?php endif; ?>
                                 <?php if ( $thumbnail_html && $view_buttons_enabled ) : ?>
                                     <div class="overlay-buttons bw-ss__overlay has-buttons">
-                                        <div class="bw-ss__buttons">
+                                        <div class="bw-ss__buttons<?php echo $has_add_to_cart ? ' bw-ss__buttons--double' : ''; ?>">
                                             <a class="overlay-button overlay-button--view bw-ss__btn bw-view-btn" href="<?php echo esc_url( $permalink ); ?>">
                                                 <span class="overlay-button__label"><?php esc_html_e( 'View Product', 'bw-elementor-widgets' ); ?></span>
                                             </a>
+                                            <?php if ( $has_add_to_cart && $add_to_cart_url ) : ?>
+                                                <a class="overlay-button overlay-button--cart bw-ss__btn bw-btn-addtocart" href="<?php echo esc_url( $add_to_cart_url ); ?>">
+                                                    <span class="overlay-button__label"><?php esc_html_e( 'Add to Cart', 'bw-elementor-widgets' ); ?></span>
+                                                </a>
+                                            <?php endif; ?>
                                         </div>
                                     </div>
                                 <?php endif; ?>


### PR DESCRIPTION
## Summary
- add a WooCommerce Add to Cart button to BW Slick Slider product overlays with a variable-product fallback
- update slider button layout styles so both actions share the existing hover and alignment treatment

## Testing
- php -l includes/widgets/class-bw-slick-slider-widget.php

------
https://chatgpt.com/codex/tasks/task_e_68dffe7801e083258d745b33eecff6f2