### PR TITLE
Fix BW Divider rendering and category registration

### DIFF
--- a/assets/css/bw-divider.css
+++ b/assets/css/bw-divider.css
@@ -7,22 +7,15 @@
 }
 
 .bw-divider svg {
-  display: inline-block;
-  max-width: 100%;
+  width: 100%;
   height: auto;
-  color: var(--bw-divider-color, #000000);
+  display: block;
 }
 
-.bw-divider svg path,
-.bw-divider svg rect,
-.bw-divider svg circle,
-.bw-divider svg ellipse,
-.bw-divider svg line,
-.bw-divider svg polyline,
-.bw-divider svg polygon {
-  fill: var(--bw-divider-color, #000000) !important;
+.bw-divider path {
+  fill: none !important;
   stroke: var(--bw-divider-color, #000000) !important;
-  stroke-width: var(--bw-divider-stroke-width, 1px);
+  stroke-width: var(--bw-divider-stroke-width, 1px) !important;
 }
 
 .bw-divider img {

--- a/bw-main-elementor-widgets.php
+++ b/bw-main-elementor-widgets.php
@@ -116,16 +116,12 @@ function bw_register_divider_style() {
 }
 
 // Aggiungi categoria personalizzata "Black Work Widgets"
-add_action( 'elementor/elements/categories_registered', static function( $elements_manager ) {
-    if ( ! method_exists( $elements_manager, 'add_category' ) ) {
-        return;
-    }
-
+add_action( 'elementor/elements/categories_registered', function( $elements_manager ) {
     $elements_manager->add_category(
-        'black-work',
+        'blackwork',
         [
-            'title' => __( 'Black Work Widgets', 'bw-elementor-widgets' ),
-            'icon'  => 'fa fa-cube',
+            'title' => __( 'Black Work Widgets', 'bw' ),
+            'icon'  => 'fa fa-plug',
         ]
     );
 } );

--- a/includes/widgets/class-bw-slick-slider-widget.php
+++ b/includes/widgets/class-bw-slick-slider-widget.php
@@ -23,7 +23,7 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
     }
 
     public function get_categories() {
-        return [ 'black-work' ];
+        return [ 'blackwork' ];
     }
 
     public function get_script_depends() {


### PR DESCRIPTION
## Summary
- ensure the BW Divider widget outputs SVG paths without fills and with stroke styling driven by Elementor controls
- update the divider stylesheet so the SVG scales correctly and the stroke color/thickness respond to CSS variables
- align the BW Divider and Slick Slider widgets under the shared "Black Work Widgets" Elementor category

## Testing
- php -l includes/widgets/class-bw-divider-widget.php
- php -l includes/widgets/class-bw-slick-slider-widget.php
- php -l bw-main-elementor-widgets.php

------
https://chatgpt.com/codex/tasks/task_e_68e3c7167a148325a813bd97bd885981