### PR TITLE
Fix fatal error from eagerly loading slide showcase widget

### DIFF
--- a/bw-main-elementor-widgets.php
+++ b/bw-main-elementor-widgets.php
@@ -30,8 +30,6 @@ require_once __DIR__ . '/includes/helpers.php';
 
 // Loader dei widget
 require_once __DIR__ . '/includes/class-bw-widget-loader.php';
-require_once( __DIR__ . '/includes/widgets/class-bw-slide-showcase-widget.php' );
-
 // Tipi di prodotto personalizzati per WooCommerce
 require_once plugin_dir_path( __FILE__ ) . 'includes/product-types/product-types-init.php';
 


### PR DESCRIPTION
## Summary
- stop including the slide showcase widget file on plugin bootstrap so Elementor can load it after its classes are available

## Testing
- php -l bw-main-elementor-widgets.php

------
https://chatgpt.com/codex/tasks/task_e_68e4448ebf1083258e57985832cf5090