### PR TITLE
Initialize slide showcase widget with Slick in Elementor

### DIFF
--- a/assets/js/bw-slick-slider.js
+++ b/assets/js/bw-slick-slider.js
@@ -249,11 +249,15 @@
       return;
     }
 
-    elementorFrontend.hooks.addAction(
+    var widgetsToInit = [
       'frontend/element_ready/bw-slick-slider.default',
-      function ($scope) {
+      'frontend/element_ready/bw-slide-showcase.default',
+    ];
+
+    widgetsToInit.forEach(function (hook) {
+      elementorFrontend.hooks.addAction(hook, function ($scope) {
         initSlickSlider($scope);
-      }
-    );
+      });
+    });
   });
 })(jQuery);


### PR DESCRIPTION
## Summary
- ensure the shared slick slider script also hooks into the slide showcase widget
- trigger Slick initialization when Elementor renders the slide showcase in the editor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4470a49b08325a97730abd5f4bc4f