### PR TITLE
Add product category filters and responsive image layout controls

### DIFF
--- a/assets/css/bw-slick-slider.css
+++ b/assets/css/bw-slick-slider.css
@@ -4,6 +4,7 @@
   --bw-columns: 3;
   --bw-gap: 24px;
   --bw-image-height: auto;
+  --bw-column-width: auto;
   --bw-overlay-buttons-background: #ffffff;
   --bw-overlay-buttons-background-hover: #f5f5f5;
   --bw-overlay-buttons-color: #000000;
@@ -19,6 +20,7 @@
 
 .bw-slick-slider .slick-slide {
   height: auto;
+  max-width: var(--bw-column-width);
 }
 
 .bw-slick-slider .bw-slick-item {

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -3,6 +3,36 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+if ( ! function_exists( 'bw_get_product_categories_options' ) ) {
+    /**
+     * Retrieve all WooCommerce product categories.
+     *
+     * @return array<int,string>
+     */
+    function bw_get_product_categories_options() {
+        $terms = get_terms(
+            [
+                'taxonomy'   => 'product_cat',
+                'hide_empty' => false,
+                'orderby'    => 'name',
+                'order'      => 'ASC',
+            ]
+        );
+
+        $options = [];
+
+        if ( empty( $terms ) || is_wp_error( $terms ) ) {
+            return $options;
+        }
+
+        foreach ( $terms as $term ) {
+            $options[ $term->term_id ] = $term->name;
+        }
+
+        return $options;
+    }
+}
+
 if ( ! function_exists( 'bw_get_parent_product_categories' ) ) {
     /**
      * Retrieve WooCommerce top-level product categories.


### PR DESCRIPTION
## Summary
- add a product category multi-select filter to the slick slider widget query configuration and honor it when building WooCommerce queries
- expose responsive image height and column width controls for the widget and wire them to CSS custom properties
- introduce a helper to fetch all product categories and expand slider styles to support adjustable column widths

## Testing
- php -l includes/helpers.php
- php -l includes/widgets/class-bw-slick-slider-widget.php

------
https://chatgpt.com/codex/tasks/task_e_68e44815442c8325a1305047e54b9779