### PR TITLE
Add column width customization to slide showcase widget

### DIFF
--- a/assets/css/bw-slide-showcase.css
+++ b/assets/css/bw-slide-showcase.css
@@ -1,3 +1,7 @@
+.bw-slide-showcase-slider {
+    --bw-slide-showcase-column-width: auto;
+}
+
 .bw-slide-showcase-slider * {
     margin: 0;
     padding: 0;
@@ -10,6 +14,7 @@
 
 .bw-slide-showcase-slider .slick-slide {
     height: auto;
+    max-width: var(--bw-slide-showcase-column-width, var(--bw-column-width, 100%));
     padding: 0 calc(var(--bw-slide-showcase-gap, var(--bw-gap, 0px)) / 2);
 }
 


### PR DESCRIPTION
## Summary
- add a responsive Elementor control to let editors choose the slide showcase column width
- update the front-end styles and rendering logic to respect the configured column width

## Testing
- php -l includes/widgets/class-bw-slide-showcase-widget.php

------
https://chatgpt.com/codex/tasks/task_e_68e44b4bbea08325a6fcdcf71817913d