### PR TITLE
Fix slick slider column width handling

### DIFF
--- a/assets/css/bw-slick-slider.css
+++ b/assets/css/bw-slick-slider.css
@@ -23,6 +23,11 @@
   max-width: var(--bw-column-width);
 }
 
+.bw-slick-slider[data-has-column-width="true"] .slick-slide {
+  width: var(--bw-column-width);
+  max-width: none;
+}
+
 .bw-slick-slider .bw-slick-item {
   padding: calc(var(--bw-gap) / 2);
   outline: none;

--- a/assets/js/bw-slick-slider.js
+++ b/assets/js/bw-slick-slider.js
@@ -201,11 +201,40 @@
     $sliders.each(function () {
       var $currentSlider = $(this);
 
+      var hasCustomColumnWidth = false;
+      var columnWidthValue = '';
+
+      if ($currentSlider.length && $currentSlider[0]) {
+        var computedStyle = window.getComputedStyle($currentSlider[0]);
+        if (computedStyle) {
+          columnWidthValue = computedStyle
+            .getPropertyValue('--bw-column-width')
+            .trim();
+
+          if (
+            columnWidthValue &&
+            columnWidthValue !== 'auto' &&
+            columnWidthValue !== 'initial' &&
+            columnWidthValue !== 'inherit' &&
+            columnWidthValue !== 'unset'
+          ) {
+            hasCustomColumnWidth = true;
+          }
+        }
+      }
+
       if ($currentSlider.hasClass('slick-initialized')) {
         $currentSlider.slick('unslick');
       }
 
       var settings = parseSettings($currentSlider);
+
+      if (hasCustomColumnWidth) {
+        $currentSlider.attr('data-has-column-width', 'true');
+        settings.variableWidth = true;
+      } else {
+        $currentSlider.removeAttr('data-has-column-width');
+      }
 
       if (typeof settings.prevArrow === 'undefined') {
         settings.prevArrow =


### PR DESCRIPTION
## Summary
- ensure the slick slider enables variable-width slides when a custom column width is configured
- add CSS that applies the configured column width to each slide when present

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e44e96dcd48325acb41b3d2236c5f5