### PR TITLE
Ensure column width adjustments trigger Elementor re-render

### DIFF
--- a/includes/widgets/class-bw-slick-slider-widget.php
+++ b/includes/widgets/class-bw-slick-slider-widget.php
@@ -391,6 +391,7 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
                 'px' => [ 'min' => 100, 'max' => 800, 'step' => 1 ],
                 '%'  => [ 'min' => 10, 'max' => 100, 'step' => 1 ],
             ],
+            'render_type' => 'template',
             'selectors'  => [
                 '{{WRAPPER}} .bw-slick-slider' => '--bw-column-width: {{SIZE}}{{UNIT}};',
             ],

--- a/includes/widgets/class-bw-slide-showcase-widget.php
+++ b/includes/widgets/class-bw-slide-showcase-widget.php
@@ -110,6 +110,7 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
                 'px' => [ 'min' => 100, 'max' => 1200, 'step' => 1 ],
                 '%'  => [ 'min' => 10, 'max' => 100, 'step' => 1 ],
             ],
+            'render_type' => 'template',
             'selectors'  => [
                 '{{WRAPPER}} .bw-slide-showcase-slider' => '--bw-slide-showcase-column-width: {{SIZE}}{{UNIT}}; --bw-column-width: {{SIZE}}{{UNIT}};',
             ],


### PR DESCRIPTION
## Summary
- trigger a full template re-render when updating the column width slider in the slick slider widget
- do the same for the slide showcase widget so Elementor shows the loading mask and refreshes the preview

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e4537ea470832595fbc8a84214d3a0