### PR TITLE
Remove drop shadow from slide showcase gallery items

### DIFF
--- a/assets/css/bw-slide-showcase.css
+++ b/assets/css/bw-slide-showcase.css
@@ -28,7 +28,7 @@
     height: var(--bw-slide-showcase-image-height, var(--bw-image-height, 600px));
     border-radius: 16px;
     overflow: hidden;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+    box-shadow: none;
 }
 
 .bw-slide-showcase-media {


### PR DESCRIPTION
## Summary
- remove the drop shadow applied to slide showcase gallery items so no shading appears behind images

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4f4803638832588893f01b7fd0286