### PR TITLE
Adjust slide showcase padding defaults

### DIFF
--- a/assets/css/bw-slide-showcase.css
+++ b/assets/css/bw-slide-showcase.css
@@ -61,10 +61,8 @@
 
 .bw-slide-showcase-content {
     position: absolute;
-    top: 50px;
-    left: 50px;
-    right: 50px;
-    bottom: 50px;
+    inset: 0;
+    padding: 0;
     display: flex;
     flex-direction: column;
     justify-content: space-between;


### PR DESCRIPTION
## Summary
- allow slide showcase content area to stretch edge-to-edge by default
- remove hardcoded offsets so layout padding controls fully govern spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4f885228c83259cb5b4ff94deff27