### PR TITLE
Enable configurable slide padding for slick slider

### DIFF
--- a/assets/css/bw-slick-slider.css
+++ b/assets/css/bw-slick-slider.css
@@ -196,7 +196,7 @@
 }
 
 .bw-slick-slider .bw-slick-item__content {
-  padding: 20px 20px 24px;
+  padding: 0;
   display: flex;
   flex-direction: column;
   gap: 12px;

--- a/includes/widgets/class-bw-slick-slider-widget.php
+++ b/includes/widgets/class-bw-slick-slider-widget.php
@@ -195,6 +195,16 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
             ],
         ] );
 
+        $this->add_responsive_control( 'slide_padding', [
+            'label' => __( 'Slide Padding', 'bw-elementor-widgets' ),
+            'type'  => Controls_Manager::DIMENSIONS,
+            'size_units' => [ 'px', '%', 'em', 'rem' ],
+            'selectors' => [
+                '{{WRAPPER}} .bw-slick-slider .bw-slick-item__content' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                '{{WRAPPER}} .bw-slick-slider .bw-ss__content' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+            ],
+        ] );
+
         $this->end_controls_section();
 
         $this->start_controls_section( 'typography_section', [


### PR DESCRIPTION
## Summary
- remove the hard-coded padding from slick slider content so there is no default spacing
- add a responsive "Slide Padding" control that exposes top, right, bottom, and left values

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4f9b6f4ec83259f6bfef5cd1f9148