### PR TITLE
Add padding controls to BW Slide Showcase widget

### DIFF
--- a/includes/widgets/class-bw-slide-showcase-widget.php
+++ b/includes/widgets/class-bw-slide-showcase-widget.php
@@ -182,6 +182,34 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
             'default' => [ 'size' => 50, 'unit' => 'px' ],
         ] );
 
+        $this->add_responsive_control(
+            'slide_padding_top',
+            [
+                'label' => __( 'Slide Padding Top', 'bw' ),
+                'type' => Controls_Manager::SLIDER,
+                'size_units' => [ 'px' ],
+                'range' => [ 'px' => [ 'min' => 0, 'max' => 200 ] ],
+                'default' => [ 'size' => 0 ],
+                'selectors' => [
+                    '{{WRAPPER}} .bw-slide-showcase-item .content' => 'padding-top: {{SIZE}}{{UNIT}};',
+                ],
+            ]
+        );
+
+        $this->add_responsive_control(
+            'slide_padding_bottom',
+            [
+                'label' => __( 'Slide Padding Bottom', 'bw' ),
+                'type' => Controls_Manager::SLIDER,
+                'size_units' => [ 'px' ],
+                'range' => [ 'px' => [ 'min' => 0, 'max' => 200 ] ],
+                'default' => [ 'size' => 0 ],
+                'selectors' => [
+                    '{{WRAPPER}} .bw-slide-showcase-item .content' => 'padding-bottom: {{SIZE}}{{UNIT}};',
+                ],
+            ]
+        );
+
         $this->end_controls_section();
     }
 
@@ -745,6 +773,24 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
         $side_padding_value  = $this->format_side_padding( isset( $settings['side_padding'] ) ? $settings['side_padding'] : [] );
         $top_spacing_value   = $this->format_slider_dimension( isset( $settings['top_spacing'] ) ? $settings['top_spacing'] : [] );
         $bottom_spacing_value = $this->format_slider_dimension( isset( $settings['bottom_spacing'] ) ? $settings['bottom_spacing'] : [] );
+        $slide_padding_top_value = $this->get_slider_value_with_unit( $settings, 'slide_padding_top', 0, 'px' );
+        $slide_padding_bottom_value = $this->get_slider_value_with_unit( $settings, 'slide_padding_bottom', 0, 'px' );
+        $padding_top         = isset( $slide_padding_top_value['size'] ) ? intval( $slide_padding_top_value['size'] ) : 0;
+        $padding_bottom      = isset( $slide_padding_bottom_value['size'] ) ? intval( $slide_padding_bottom_value['size'] ) : 0;
+        $content_style_parts = [];
+
+        $base_content_style = $this->build_content_style( $side_padding_value, $top_spacing_value, $bottom_spacing_value );
+        if ( $base_content_style ) {
+            $content_style_parts[] = $base_content_style;
+        }
+
+        $content_style_parts[] = sprintf(
+            'padding-top:%dpx; padding-bottom:%dpx;',
+            $padding_top,
+            $padding_bottom
+        );
+
+        $content_style = trim( implode( ' ', $content_style_parts ) );
         $object_fit          = $image_crop ? 'cover' : 'contain';
         $button_text         = ! empty( $settings['view_button_text'] ) ? $settings['view_button_text'] : __( 'View Collection', 'bw-elementor-widgets' );
         $custom_link         = isset( $settings['view_button_link'] ) ? $settings['view_button_link'] : [];
@@ -813,7 +859,7 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
                                     <div class="bw-slide-showcase-overlay" style="opacity: <?php echo esc_attr( $mask_opacity ); ?>;"></div>
                                 <?php endif; ?>
                             </div>
-                            <div class="bw-slide-showcase-content" style="<?php echo $this->build_content_style( $side_padding_value, $top_spacing_value, $bottom_spacing_value ); ?>">
+                            <div class="bw-slide-showcase-content content" style="<?php echo esc_attr( $content_style ); ?>">
                                 <div class="bw-slide-showcase-title-section">
                                     <h1><?php echo esc_html( $title ); ?></h1>
                                     <?php if ( $subtitle ) : ?>
@@ -1113,7 +1159,7 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
             $styles[] = 'padding-bottom: ' . $bottom_spacing . ';';
         }
 
-        return esc_attr( implode( ' ', $styles ) );
+        return implode( ' ', $styles );
     }
 
     private function build_image_style( $image_height, $object_fit ) {


### PR DESCRIPTION
## Summary
- add responsive top and bottom slide padding controls to the BW Slide Showcase layout settings
- render the selected padding values on the frontend by applying inline styles to the slide content wrapper

## Testing
- php -l includes/widgets/class-bw-slide-showcase-widget.php

------
https://chatgpt.com/codex/tasks/task_e_68e4fc17b0d883259ae5c4e96b626d5f