### PR TITLE
Adjust slide showcase info layout

### DIFF
--- a/assets/css/bw-slide-showcase.css
+++ b/assets/css/bw-slide-showcase.css
@@ -96,6 +96,18 @@
     gap: 16px;
 }
 
+.pwslideshowkeyinfoitem {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.pwslideshowkeyinfoitem__value {
+    display: inline-flex;
+    align-items: center;
+    white-space: nowrap;
+}
+
 .bw-slide-showcase-info-item {
     display: flex;
     align-items: center;

--- a/includes/widgets/class-bw-slide-showcase-widget.php
+++ b/includes/widgets/class-bw-slide-showcase-widget.php
@@ -868,15 +868,17 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
                                 </div>
                                 <div class="bw-slide-showcase-bottom-section">
                                     <div class="bw-slide-showcase-info">
-                                        <div>
-                                            <div class="bw-slide-showcase-info-item">29 Assets</div>
+                                        <div class="bw-slide-showcase-info-item pwslideshowkeyinfoitem">
+                                            <span class="pwslideshowkeyinfoitem__value">29 Assets</span>
                                             <div class="bw-slide-showcase-badges">
                                                 <span class="bw-slide-showcase-badge">SVG</span>
                                                 <span class="bw-slide-showcase-badge">EPS</span>
                                                 <span class="bw-slide-showcase-badge">PNG</span>
                                             </div>
                                         </div>
-                                        <div class="bw-slide-showcase-info-item">95.2MB</div>
+                                        <div class="bw-slide-showcase-info-item pwslideshowkeyinfoitem">
+                                            <span class="pwslideshowkeyinfoitem__value">95.2MB</span>
+                                        </div>
                                     </div>
                                     <a href="<?php echo esc_url( $btn_url ); ?>" class="bw-slide-showcase-view-btn"<?php echo $link_attrs; ?>>
                                         <span class="bw-slide-showcase-arrow">→</span>


### PR DESCRIPTION
## Summary
- refactor the slide showcase key info markup to use pwslideshowkeyinfoitem wrappers
- add css rules so the key info items and badges stay aligned on a single row

## Testing
- php -l includes/widgets/class-bw-slide-showcase-widget.php

------
https://chatgpt.com/codex/tasks/task_e_68e50e6003848325873770842c1cb59d