### PR TITLE
Reorder slide showcase info row elements

### DIFF
--- a/includes/widgets/class-bw-slide-showcase-widget.php
+++ b/includes/widgets/class-bw-slide-showcase-widget.php
@@ -870,14 +870,14 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
                                     <div class="bw-slide-showcase-info">
                                         <div class="bw-slide-showcase-info-item pwslideshowkeyinfoitem">
                                             <span class="pwslideshowkeyinfoitem__value">29 Assets</span>
-                                            <div class="bw-slide-showcase-badges">
-                                                <span class="bw-slide-showcase-badge">SVG</span>
-                                                <span class="bw-slide-showcase-badge">EPS</span>
-                                                <span class="bw-slide-showcase-badge">PNG</span>
-                                            </div>
                                         </div>
                                         <div class="bw-slide-showcase-info-item pwslideshowkeyinfoitem">
                                             <span class="pwslideshowkeyinfoitem__value">95.2MB</span>
+                                        </div>
+                                        <div class="bw-slide-showcase-badges">
+                                            <span class="bw-slide-showcase-badge">SVG</span>
+                                            <span class="bw-slide-showcase-badge">EPS</span>
+                                            <span class="bw-slide-showcase-badge">PNG</span>
                                         </div>
                                     </div>
                                     <a href="<?php echo esc_url( $btn_url ); ?>" class="bw-slide-showcase-view-btn"<?php echo $link_attrs; ?>>


### PR DESCRIPTION
## Summary
- reorder the slide showcase info row so the borderless metrics appear before the format badges

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e5102f43ec83258caa7c5eed3e3722