### PR TITLE
Add navigation arrow style controls to slide showcase widget

### DIFF
--- a/includes/widgets/class-bw-slide-showcase-widget.php
+++ b/includes/widgets/class-bw-slide-showcase-widget.php
@@ -646,6 +646,125 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
         $this->end_controls_tabs();
 
         $this->end_controls_section();
+
+        $this->start_controls_section(
+            'section_arrows_style',
+            [
+                'label' => __( 'Navigation Arrows', 'bw' ),
+                'tab'   => Controls_Manager::TAB_STYLE,
+            ]
+        );
+
+        $this->add_control(
+            'arrows_color',
+            [
+                'label' => __( 'Arrow Color', 'bw' ),
+                'type'  => Controls_Manager::COLOR,
+                'selectors' => [
+                    '{{WRAPPER}} .bw-slide-showcase-slider .bw-slick-prev img, {{WRAPPER}} .bw-slide-showcase-slider .bw-slick-next img' => 'filter: brightness(0) saturate(100%) invert(0%) sepia(0%) saturate(0%) hue-rotate(0deg) brightness(0) contrast(100%) drop-shadow(0 0 0 {{VALUE}});',
+                ],
+            ]
+        );
+
+        $this->add_responsive_control(
+            'arrows_size',
+            [
+                'label' => __( 'Arrow Size', 'bw' ),
+                'type' => Controls_Manager::SLIDER,
+                'range' => [
+                    'px' => [ 'min' => 10, 'max' => 100 ],
+                ],
+                'default' => [
+                    'size' => 30,
+                    'unit' => 'px',
+                ],
+                'selectors' => [
+                    '{{WRAPPER}} .bw-slide-showcase-slider .bw-slick-prev img, {{WRAPPER}} .bw-slide-showcase-slider .bw-slick-next img' => 'width: {{SIZE}}{{UNIT}}; height: auto;',
+                ],
+            ]
+        );
+
+        $this->add_responsive_control(
+            'arrows_padding',
+            [
+                'label' => __( 'Arrow Padding', 'bw' ),
+                'type' => Controls_Manager::DIMENSIONS,
+                'size_units' => [ 'px', '%' ],
+                'default' => [
+                    'top' => 0,
+                    'right' => 0,
+                    'bottom' => 0,
+                    'left' => 0,
+                    'unit' => 'px',
+                    'isLinked' => true,
+                ],
+                'selectors' => [
+                    '{{WRAPPER}} .bw-slide-showcase-slider .bw-slick-prev, {{WRAPPER}} .bw-slide-showcase-slider .bw-slick-next' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                ],
+            ]
+        );
+
+        $this->add_responsive_control(
+            'arrows_vertical_offset',
+            [
+                'label' => __( 'Vertical Offset', 'bw' ),
+                'type'  => Controls_Manager::SLIDER,
+                'size_units' => [ 'px', '%' ],
+                'range' => [
+                    'px' => [ 'min' => -300, 'max' => 300, 'step' => 1 ],
+                    '%'  => [ 'min' => -100, 'max' => 100, 'step' => 1 ],
+                ],
+                'default' => [
+                    'size' => 15,
+                    'unit' => 'px',
+                ],
+                'selectors' => [
+                    '{{WRAPPER}} .bw-slide-showcase-slider .bw-slick-prev, {{WRAPPER}} .bw-slide-showcase-slider .bw-slick-next' => 'bottom: {{SIZE}}{{UNIT}};',
+                ],
+            ]
+        );
+
+        $this->add_responsive_control(
+            'arrows_prev_horizontal_offset',
+            [
+                'label' => __( 'Previous Arrow Horizontal Offset', 'bw' ),
+                'type'  => Controls_Manager::SLIDER,
+                'size_units' => [ 'px', '%' ],
+                'range' => [
+                    'px' => [ 'min' => -300, 'max' => 300, 'step' => 1 ],
+                    '%'  => [ 'min' => -100, 'max' => 100, 'step' => 1 ],
+                ],
+                'default' => [
+                    'size' => 55,
+                    'unit' => 'px',
+                ],
+                'selectors' => [
+                    '{{WRAPPER}} .bw-slide-showcase-slider .bw-slick-prev' => 'right: {{SIZE}}{{UNIT}};',
+                ],
+            ]
+        );
+
+        $this->add_responsive_control(
+            'arrows_next_horizontal_offset',
+            [
+                'label' => __( 'Next Arrow Horizontal Offset', 'bw' ),
+                'type'  => Controls_Manager::SLIDER,
+                'size_units' => [ 'px', '%' ],
+                'range' => [
+                    'px' => [ 'min' => -300, 'max' => 300, 'step' => 1 ],
+                    '%'  => [ 'min' => -100, 'max' => 100, 'step' => 1 ],
+                ],
+                'default' => [
+                    'size' => 15,
+                    'unit' => 'px',
+                ],
+                'selectors' => [
+                    '{{WRAPPER}} .bw-slide-showcase-slider .bw-slick-next' => 'right: {{SIZE}}{{UNIT}};',
+                ],
+            ]
+        );
+
+        $this->end_controls_section();
     }
 
     protected function render() {


### PR DESCRIPTION
## Summary
- add a Navigation Arrows style section to the BW Slide Showcase widget
- expose responsive controls for arrow color, size, padding, and offsets to mirror the Slick Slider configuration

## Testing
- php -l includes/widgets/class-bw-slide-showcase-widget.php

------
https://chatgpt.com/codex/tasks/task_e_68e5182f59a88325a858e26525c914ed