### PR TITLE
Update slide showcase button arrow styling

### DIFF
--- a/assets/css/bw-slide-showcase.css
+++ b/assets/css/bw-slide-showcase.css
@@ -159,17 +159,22 @@
 }
 
 .bw-slide-showcase-arrow {
-    width: 24px;
-    height: 24px;
+    width: 26px;
+    height: 26px;
     display: flex;
     align-items: center;
     justify-content: center;
+    background: #80FD03;
     border: 1px solid #000;
     border-radius: 50%;
-    font-size: 1rem;
-    color: #000;
-    background: transparent;
     flex-shrink: 0;
+}
+
+.bw-slide-showcase-arrow img {
+    width: 10px;
+    height: auto;
+    display: block;
+    filter: invert(0);
 }
 
 @media (max-width: 768px) {

--- a/includes/widgets/class-bw-slide-showcase-widget.php
+++ b/includes/widgets/class-bw-slide-showcase-widget.php
@@ -1013,7 +1013,9 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
                                         </div>
                                     <?php endif; ?>
                                     <a href="<?php echo esc_url( $btn_url ); ?>" class="bw-slide-showcase-view-btn"<?php echo $link_attrs; ?>>
-                                        <span class="bw-slide-showcase-arrow">&rsaquo;</span>
+                                        <span class="bw-slide-showcase-arrow">
+                                            <img src="<?php echo BW_MEW_URL . 'assets/img/button_arrow.svg'; ?>" alt="arrow">
+                                        </span>
                                         <?php echo esc_html( $button_text_value ); ?>
                                     </a>
                                 </div>


### PR DESCRIPTION
## Summary
- embed the slide showcase button arrow SVG within the button markup
- restyle the button and arrow container to match the requested green circular design

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6330c6be88325841c6b75c13fe2fb