### PR TITLE
feat: modernize slide showcase button styling

### DIFF
--- a/assets/css/bw-slide-showcase.css
+++ b/assets/css/bw-slide-showcase.css
@@ -136,45 +136,68 @@
     line-height: 1;
 }
 
-.bw-slide-showcase-view-btn {
-    display: inline-flex;
+/* =============================
+   MODERN BUTTON (dual style)
+   ============================= */
+
+.bw-slide-showcase-button-container {
+    display: flex;
     align-items: center;
-    gap: 10px;
-    padding: 14px 32px;
-    background: #80FD03;
-    color: #000;
-    border: 1px solid #000;
-    border-radius: 50px;
-    font-size: 1rem;
-    font-weight: 600;
-    line-height: 1;
-    text-decoration: none;
-    cursor: pointer;
-    transition: background 0.3s ease, filter 0.3s ease;
+    gap: 20px;
+    position: relative;
+    z-index: 5;
 }
 
-.bw-slide-showcase-view-btn:hover {
-    background: #9FFF32;
-    filter: brightness(1.05);
-}
-
-.bw-slide-showcase-arrow {
-    width: 26px;
-    height: 26px;
+.bw-slide-showcase-arrow-btn {
+    width: var(--arrow-size, 46px);
+    height: var(--arrow-size, 46px);
+    background-color: var(--arrow-bg, #80FD03);
+    border: var(--arrow-border-width, 1px) solid var(--arrow-border-color, #000);
+    border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: #80FD03;
-    border: 1px solid #000;
-    border-radius: 50%;
+    cursor: pointer;
+    transition: all 0.3s ease;
     flex-shrink: 0;
+    margin: var(--arrow-margin, 0);
 }
 
-.bw-slide-showcase-arrow img {
-    width: 10px;
-    height: auto;
+.bw-slide-showcase-arrow-btn img,
+.bw-slide-showcase-arrow-btn svg {
+    width: 20px;
+    height: 20px;
     display: block;
-    filter: invert(0);
+    stroke: var(--arrow-icon-color, #000);
+    stroke-width: 2.5;
+    fill: none;
+}
+
+.bw-slide-showcase-text-btn {
+    background-color: var(--btn-bg, #80FD03);
+    color: var(--btn-color, #000);
+    border: var(--btn-border-width, 1px) solid var(--btn-border-color, #000);
+    padding: var(--btn-padding, 14px 32px);
+    border-radius: 25px;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.bw-slide-showcase-button-container:hover .bw-slide-showcase-arrow-btn {
+    transform: translateX(-2px) scale(1.05);
+}
+
+.bw-slide-showcase-button-container:hover .bw-slide-showcase-text-btn {
+    transform: translateX(2px);
+}
+
+.bw-slide-showcase-arrow-btn:hover,
+.bw-slide-showcase-text-btn:hover {
+    background-color: #9FFF32;
 }
 
 @media (max-width: 768px) {

--- a/includes/widgets/class-bw-slide-showcase-widget.php
+++ b/includes/widgets/class-bw-slide-showcase-widget.php
@@ -431,6 +431,111 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
             ],
         ] );
 
+        $this->add_control(
+            'button_color',
+            [
+                'label'   => __( 'Colore principale pulsante', 'bw' ),
+                'type'    => Controls_Manager::COLOR,
+                'default' => '#80FD03',
+                'selectors' => [
+                    '{{WRAPPER}}' => '--btn-bg: {{VALUE}}; --arrow-bg: {{VALUE}};',
+                ],
+            ]
+        );
+
+        $this->add_control(
+            'button_text_color',
+            [
+                'label'   => __( 'Colore testo pulsante', 'bw' ),
+                'type'    => Controls_Manager::COLOR,
+                'default' => '#000000',
+                'selectors' => [
+                    '{{WRAPPER}}' => '--btn-color: {{VALUE}};',
+                ],
+            ]
+        );
+
+        $this->add_control(
+            'button_border_color',
+            [
+                'label'   => __( 'Colore bordo pulsante', 'bw' ),
+                'type'    => Controls_Manager::COLOR,
+                'default' => '#000000',
+                'selectors' => [
+                    '{{WRAPPER}}' => '--btn-border-color: {{VALUE}}; --arrow-border-color: {{VALUE}};',
+                ],
+            ]
+        );
+
+        $this->add_responsive_control(
+            'button_border_width',
+            [
+                'label' => __( 'Spessore bordo (px)', 'bw' ),
+                'type'  => Controls_Manager::SLIDER,
+                'size_units' => [ 'px' ],
+                'range' => [
+                    'px' => [ 'min' => 0, 'max' => 10 ],
+                ],
+                'default' => [ 'size' => 1, 'unit' => 'px' ],
+                'selectors' => [
+                    '{{WRAPPER}}' => '--btn-border-width: {{SIZE}}{{UNIT}}; --arrow-border-width: {{SIZE}}{{UNIT}};',
+                ],
+            ]
+        );
+
+        $this->add_responsive_control(
+            'arrow_margin',
+            [
+                'label' => __( 'Margini sfera freccia', 'bw' ),
+                'type'  => Controls_Manager::DIMENSIONS,
+                'size_units' => [ 'px', '%' ],
+                'default' => [
+                    'top' => 0,
+                    'right' => 0,
+                    'bottom' => 0,
+                    'left' => 0,
+                    'unit' => 'px',
+                    'isLinked' => true,
+                ],
+                'selectors' => [
+                    '{{WRAPPER}}' => '--arrow-margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                ],
+            ]
+        );
+
+        $this->add_responsive_control(
+            'arrow_size',
+            [
+                'label' => __( 'Dimensione sfera freccia', 'bw' ),
+                'type'  => Controls_Manager::SLIDER,
+                'range' => [ 'px' => [ 'min' => 20, 'max' => 100 ] ],
+                'default' => [ 'size' => 46, 'unit' => 'px' ],
+                'selectors' => [
+                    '{{WRAPPER}}' => '--arrow-size: {{SIZE}}{{UNIT}};',
+                ],
+            ]
+        );
+
+        $this->add_responsive_control(
+            'button_padding',
+            [
+                'label' => __( 'Padding pulsante testo', 'bw' ),
+                'type'  => Controls_Manager::DIMENSIONS,
+                'size_units' => [ 'px' ],
+                'default' => [
+                    'top' => 14,
+                    'right' => 32,
+                    'bottom' => 14,
+                    'left' => 32,
+                    'unit' => 'px',
+                    'isLinked' => false,
+                ],
+                'selectors' => [
+                    '{{WRAPPER}}' => '--btn-padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
+                ],
+            ]
+        );
+
         $this->end_controls_section();
     }
 
@@ -1012,12 +1117,14 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
                                             <?php endif; ?>
                                         </div>
                                     <?php endif; ?>
-                                    <a href="<?php echo esc_url( $btn_url ); ?>" class="bw-slide-showcase-view-btn"<?php echo $link_attrs; ?>>
-                                        <span class="bw-slide-showcase-arrow">
+                                    <div class="bw-slide-showcase-button-container">
+                                        <button class="bw-slide-showcase-arrow-btn" aria-label="Go">
                                             <img src="<?php echo BW_MEW_URL . 'assets/img/button_arrow.svg'; ?>" alt="arrow">
-                                        </span>
-                                        <?php echo esc_html( $button_text_value ); ?>
-                                    </a>
+                                        </button>
+                                        <a href="<?php echo esc_url( $btn_url ); ?>" class="bw-slide-showcase-text-btn"<?php echo $link_attrs; ?>>
+                                            <?php echo esc_html( $button_text_value ); ?>
+                                        </a>
+                                    </div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- replace the slide showcase call-to-action markup with the modern dual-button layout
- refresh the widget stylesheet to support the new animated arrow and text buttons via CSS variables
- expose Elementor controls that map to the new button design tokens for live customization

## Testing
- php -l includes/widgets/class-bw-slide-showcase-widget.php

------
https://chatgpt.com/codex/tasks/task_e_68e63982f3e4832589eae304f6b39a4a