### PR TITLE
Fix Elementor widget loading fatal error

### DIFF
--- a/bw-main-elementor-widgets.php
+++ b/bw-main-elementor-widgets.php
@@ -30,7 +30,6 @@ require_once __DIR__ . '/includes/helpers.php';
 
 // Loader dei widget
 require_once __DIR__ . '/includes/class-bw-widget-loader.php';
-require_once( __DIR__ . '/includes/widgets/class-bw-product-slide-widget.php' );
 // Tipi di prodotto personalizzati per WooCommerce
 require_once plugin_dir_path( __FILE__ ) . 'includes/product-types/product-types-init.php';
 // Metabox per prodotti digitali


### PR DESCRIPTION
## Summary
- stop loading the product slide widget file during plugin bootstrap to avoid early access to Elementor classes

## Testing
- php -l bw-main-elementor-widgets.php

------
https://chatgpt.com/codex/tasks/task_e_68e66333626c83258f4dca0d7df424dc