### PR TITLE
Fix Elementor slider initialization in the editor preview

### DIFF
--- a/assets/js/bw-product-slide.js
+++ b/assets/js/bw-product-slide.js
@@ -141,12 +141,31 @@
     initProductSlide($(document));
   });
 
-  if (window.elementorFrontend && window.elementorFrontend.hooks) {
-    window.elementorFrontend.hooks.addAction(
+  var productSlideHooksRegistered = false;
+  var registerElementorHooks = function () {
+    if (productSlideHooksRegistered) {
+      return;
+    }
+
+    var frontend = window.elementorFrontend;
+    if (
+      !frontend ||
+      !frontend.hooks ||
+      typeof frontend.hooks.addAction !== 'function'
+    ) {
+      return;
+    }
+
+    productSlideHooksRegistered = true;
+
+    frontend.hooks.addAction(
       'frontend/element_ready/bw-product-slide.default',
       function ($scope) {
         initProductSlide($scope);
       }
     );
-  }
+  };
+
+  registerElementorHooks();
+  $(window).on('elementor/frontend/init', registerElementorHooks);
 })(jQuery);

--- a/assets/js/bw-slick-slider.js
+++ b/assets/js/bw-slick-slider.js
@@ -375,7 +375,12 @@
     initSlickSlider($(document));
   });
 
-  $(window).on('elementor/frontend/init', function () {
+  var hooksRegistered = false;
+  var registerElementorHooks = function () {
+    if (hooksRegistered) {
+      return;
+    }
+
     if (
       typeof elementorFrontend === 'undefined' ||
       !elementorFrontend.hooks ||
@@ -383,6 +388,8 @@
     ) {
       return;
     }
+
+    hooksRegistered = true;
 
     var widgetsToInit = [
       'frontend/element_ready/bw-slick-slider.default',
@@ -394,5 +401,8 @@
         initSlickSlider($scope);
       });
     });
-  });
+  };
+
+  registerElementorHooks();
+  $(window).on('elementor/frontend/init', registerElementorHooks);
 })(jQuery);


### PR DESCRIPTION
## Summary
- ensure the slick slider script registers Elementor hooks even when Elementor has already initialised so sliders rebuild in the editor preview
- apply the same deferred hook registration pattern to the product slide script to keep previews in sync with the frontend

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6652864288325afb449724bd48fb8