### PR TITLE
Update BW Product Slide popup layout and behavior

### DIFF
--- a/assets/css/bw-product-slide.css
+++ b/assets/css/bw-product-slide.css
@@ -77,19 +77,21 @@
     opacity: 0.7;
 }
 
-/* POPUP FULLSCREEN */
+/* =============================
+   POPUP FULLSCREEN STYLE
+   ============================= */
+
 .bw-product-slide-popup {
     position: fixed;
     inset: 0;
-    background: rgba(255, 255, 255, 0.98);
+    background: #ffffff;
     display: none;
-    justify-content: center;
-    align-items: flex-start;
+    flex-direction: column;
+    align-items: center;
     overflow-y: auto;
     z-index: 9999;
     opacity: 0;
     transition: opacity 0.4s ease;
-    padding: 60px 0;
 }
 
 .bw-product-slide-popup.active {
@@ -97,32 +99,86 @@
     opacity: 1;
 }
 
-.bw-popup-close {
-    position: fixed;
-    top: 20px;
-    right: 30px;
-    background: none;
-    border: none;
-    cursor: pointer;
+/* Header (titolo + X) */
+.bw-product-slide-popup-header {
+    position: sticky;
+    top: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: #fff;
+    border-bottom: 1px solid rgba(0,0,0,0.1);
+    padding: 20px 40px;
     z-index: 10000;
 }
 
-.bw-popup-close img {
-    width: 24px;
-    height: 24px;
+.bw-popup-title {
+    font-size: 20px;
+    font-weight: 600;
+    color: #000;
+    font-family: 'Inter', sans-serif;
 }
 
+.bw-popup-close-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.2s ease;
+}
+
+.bw-popup-close-btn:hover {
+    transform: scale(1.1);
+}
+
+.bw-popup-close-btn .close-icon {
+    stroke: #000;
+    stroke-width: 2;
+    fill: none;
+}
+
+/* Contenuto immagini */
 .bw-popup-content {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 40px;
-    width: min(1800px, 100%);
+    justify-content: flex-start;
+    padding: 60px 0;
+    gap: 25px;
+    width: 100%;
 }
 
 .bw-popup-content img {
     width: 100%;
+    max-width: 1800px;
     height: auto;
+    display: block;
+    margin: 0 auto;
+}
+
+/* Fade effect body scroll lock */
+body.popup-active {
+    overflow: hidden;
+}
+
+@media (max-width: 768px) {
+    .bw-popup-title {
+        font-size: 16px;
+    }
+    .bw-popup-close-btn .close-icon {
+        width: 36px;
+        height: 36px;
+    }
+    .bw-popup-content {
+        padding: 40px 0;
+        gap: 20px;
+    }
 }
 
 .bw-product-slide-placeholder {

--- a/assets/js/bw-product-slide.js
+++ b/assets/js/bw-product-slide.js
@@ -31,25 +31,30 @@
       return;
     }
 
+    var $body = $('body');
+    var $popupTitle = $popup.find('.bw-popup-title');
+
     var openPopup = function () {
       $popup.addClass('active');
-      $('body').addClass('bw-product-slide-popup-open').css('overflow', 'hidden');
+      $body.addClass('popup-active');
     };
 
     var closePopup = function () {
       $popup.removeClass('active');
-      $('body').removeClass('bw-product-slide-popup-open').css('overflow', '');
+      $body.removeClass('popup-active');
     };
 
     $container
       .find('.bw-product-slide-item img')
       .off('click.bwProductSlide')
       .on('click.bwProductSlide', function () {
+        var title = $(this).attr('alt') || '';
+        $popupTitle.text(title);
         openPopup();
       });
 
     $container
-      .find('.bw-popup-close')
+      .find('.bw-popup-close-btn')
       .off('click.bwProductSlide')
       .on('click.bwProductSlide', function (event) {
         event.preventDefault();

--- a/includes/widgets/class-bw-product-slide-widget.php
+++ b/includes/widgets/class-bw-product-slide-widget.php
@@ -143,7 +143,9 @@ class Widget_Bw_Product_Slide extends Widget_Bw_Slide_Showcase {
                 }
 
                 $slides[] = [
-                    'image' => $image_url,
+                    'image' => [
+                        'url' => $image_url,
+                    ],
                     'title' => get_the_title( $post_id ),
                 ];
             }
@@ -157,6 +159,7 @@ class Widget_Bw_Product_Slide extends Widget_Bw_Slide_Showcase {
         }
 
         $total_slides = count( $slides );
+        $product_title = ! empty( $slides ) ? $slides[0]['title'] : '';
         $wrapper_style  = '--bw-product-slide-gap:' . $gap . 'px;';
         if ( $image_height > 0 ) {
             $wrapper_style .= '--bw-product-slide-image-height:' . $image_height . 'px;';
@@ -178,7 +181,7 @@ class Widget_Bw_Product_Slide extends Widget_Bw_Slide_Showcase {
             >
                 <?php foreach ( $slides as $index => $slide ) : ?>
                     <div class="bw-product-slide-item" data-index="<?php echo esc_attr( $index + 1 ); ?>">
-                        <img src="<?php echo esc_url( $slide['image'] ); ?>" alt="<?php echo esc_attr( $slide['title'] ); ?>" style="<?php echo esc_attr( $image_style ); ?>">
+                        <img src="<?php echo esc_url( $slide['image']['url'] ); ?>" alt="<?php echo esc_attr( $slide['title'] ); ?>" style="<?php echo esc_attr( $image_style ); ?>">
                     </div>
                 <?php endforeach; ?>
             </div>
@@ -195,13 +198,25 @@ class Widget_Bw_Product_Slide extends Widget_Bw_Slide_Showcase {
                     </button>
                 </div>
             </div>
-            <div class="bw-product-slide-popup" aria-hidden="true">
-                <button class="bw-popup-close" type="button" aria-label="<?php esc_attr_e( 'Chiudi popup', 'bw-elementor-widgets' ); ?>">
-                    <img src="<?php echo esc_url( BW_MEW_URL . 'assets/img/close.svg' ); ?>" alt="<?php esc_attr_e( 'Chiudi', 'bw-elementor-widgets' ); ?>">
-                </button>
+            <!-- POPUP FULLSCREEN -->
+            <div class="bw-product-slide-popup">
+                <div class="bw-product-slide-popup-header">
+                    <div class="bw-popup-title"><?php echo esc_html( $product_title ); ?></div>
+                    <div class="bw-popup-close">
+                        <button class="bw-popup-close-btn" aria-label="Close">
+                            <svg class="close-icon" viewBox="0 0 40 40" width="50" height="50">
+                                <line x1="10" y1="10" x2="30" y2="30"></line>
+                                <line x1="30" y1="10" x2="10" y2="30"></line>
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+
                 <div class="bw-popup-content">
                     <?php foreach ( $slides as $slide ) : ?>
-                        <img src="<?php echo esc_url( $slide['image'] ); ?>" alt="<?php echo esc_attr( $slide['title'] ); ?>" class="bw-popup-img">
+                        <img src="<?php echo esc_url( $slide['image']['url'] ); ?>"
+                             alt="<?php echo esc_attr( $slide['title'] ); ?>"
+                             class="bw-popup-img">
                     <?php endforeach; ?>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- replace the product slide popup markup with the new fullscreen layout and inline SVG close icon
- restyle the popup to a white fullscreen layout with sticky header and vertically spaced images
- streamline the popup JavaScript to fade the overlay, lock body scroll, and sync the header title with the clicked slide

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e68006f9e88325afa35aee7c71affe