### PR TITLE
Refine popup image styling

### DIFF
--- a/assets/css/bw-product-slide.css
+++ b/assets/css/bw-product-slide.css
@@ -78,7 +78,7 @@
 }
 
 /* =============================
-   POPUP FULLSCREEN STYLE
+   POPUP FULLSCREEN OTTIMIZZATO
    ============================= */
 
 .bw-product-slide-popup {
@@ -99,7 +99,6 @@
     opacity: 1;
 }
 
-/* Header (titolo + X) */
 .bw-product-slide-popup-header {
     position: sticky;
     top: 0;
@@ -143,23 +142,31 @@
     fill: none;
 }
 
-/* Contenuto immagini */
 .bw-popup-content {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: flex-start;
     padding: 60px 0;
-    gap: 25px;
     width: 100%;
 }
 
-.bw-popup-content img {
+.bw-popup-img {
+    display: block;
     width: 100%;
     max-width: 1800px;
     height: auto;
-    display: block;
-    margin: 0 auto;
+    margin: 0 auto 25px auto;
+    object-fit: contain;
+    transition: transform 0.3s ease;
+}
+
+.bw-popup-img:last-child {
+    margin-bottom: 0;
+}
+
+.bw-popup-img:hover {
+    transform: scale(1.02);
 }
 
 /* Fade effect body scroll lock */
@@ -177,7 +184,10 @@ body.popup-active {
     }
     .bw-popup-content {
         padding: 40px 0;
-        gap: 20px;
+    }
+    .bw-popup-img {
+        max-width: 95%;
+        margin-bottom: 20px;
     }
 }
 


### PR DESCRIPTION
## Summary
- align the fullscreen popup styles with the updated design by consolidating spacing and sizing rules on `.bw-popup-img`
- keep the popup content wrapper for vertical layout responsibilities while preserving existing header behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6865a73f8832591e4700b6aa12894