### PR TITLE
Remove unused slide showcase mask controls and fix width handling

### DIFF
--- a/assets/css/bw-slide-showcase.css
+++ b/assets/css/bw-slide-showcase.css
@@ -14,9 +14,13 @@
 
 .bw-slide-showcase-slider .slick-slide {
     height: auto;
-    max-width: var(--bw-slide-showcase-column-width, var(--bw-column-width, 100%));
-    width: var(--bw-slide-showcase-column-width, var(--bw-column-width, auto));
     padding: 0 calc(var(--bw-slide-showcase-gap, var(--bw-gap, 0px)) / 2);
+}
+
+.bw-slide-showcase-slider .bw-slide-showcase-slide {
+    width: var(--bw-slide-showcase-column-width, var(--bw-column-width, auto));
+    max-width: var(--bw-slide-showcase-column-width, var(--bw-column-width, 100%));
+    flex: 0 0 auto;
 }
 
 .bw-slide-showcase-slide {
@@ -49,15 +53,6 @@
 
 .bw-slide-showcase--no-crop .bw-slide-showcase-image {
     object-fit: contain;
-}
-
-.bw-slide-showcase-overlay {
-    position: absolute;
-    inset: 0;
-    background: #000;
-    opacity: 0.6;
-    pointer-events: none;
-    border-radius: inherit;
 }
 
 .bw-slide-showcase-content {

--- a/includes/widgets/class-bw-slide-showcase-widget.php
+++ b/includes/widgets/class-bw-slide-showcase-widget.php
@@ -200,27 +200,6 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
             ],
         ] );
 
-        $this->add_control( 'image_mask', [
-            'label'        => __( 'Maschera nera', 'bw-elementor-widgets' ),
-            'type'         => Controls_Manager::SWITCHER,
-            'label_on'     => __( 'On', 'bw-elementor-widgets' ),
-            'label_off'    => __( 'Off', 'bw-elementor-widgets' ),
-            'return_value' => 'yes',
-            'default'      => 'yes',
-        ] );
-
-        $this->add_control( 'image_mask_opacity', [
-            'label'       => __( 'Opacità maschera', 'bw-elementor-widgets' ),
-            'type'        => Controls_Manager::NUMBER,
-            'min'         => 0,
-            'max'         => 1,
-            'step'        => 0.05,
-            'default'     => 0.6,
-            'condition'   => [
-                'image_mask' => 'yes',
-            ],
-        ] );
-
         $this->end_controls_section();
     }
 
@@ -826,10 +805,6 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
         $column_width_data  = $this->get_slider_value_with_unit( $settings, 'column_width', null, 'px' );
         $column_width       = isset( $column_width_data['size'] ) ? $column_width_data['size'] : null;
         $column_width_unit  = isset( $column_width_data['unit'] ) ? $column_width_data['unit'] : 'px';
-        $mask_enabled       = ! isset( $settings['image_mask'] ) || 'yes' === $settings['image_mask'];
-        $mask_opacity_value = isset( $settings['image_mask_opacity'] ) ? (float) $settings['image_mask_opacity'] : 0.6;
-        $mask_opacity       = max( 0, min( 1, $mask_opacity_value ) );
-
         $available_post_types = $this->get_post_type_options();
         if ( empty( $available_post_types ) ) {
             $available_post_types = [ 'post' => __( 'Post', 'bw-elementor-widgets' ) ];
@@ -997,9 +972,6 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
                             <div class="bw-slide-showcase-media">
                                 <?php if ( $image_url ) : ?>
                                     <img src="<?php echo esc_url( $image_url ); ?>" alt="<?php echo esc_attr( $title ); ?>" class="bw-slide-showcase-image" style="<?php echo $this->build_image_style( $image_height, $object_fit ); ?>">
-                                <?php endif; ?>
-                                <?php if ( $mask_enabled ) : ?>
-                                    <div class="bw-slide-showcase-overlay" style="opacity: <?php echo esc_attr( $mask_opacity ); ?>;"></div>
                                 <?php endif; ?>
                             </div>
                             <div class="bw-slide-showcase-content content"<?php echo $content_style ? ' style="' . esc_attr( $content_style ) . '"' : ''; ?>>


### PR DESCRIPTION
## Summary
- remove the unused "Maschera nera" controls and related overlay markup from the Slide Showcase widget
- adjust the Slide Showcase styles so each slide honours the configured column width

## Testing
- php -l includes/widgets/class-bw-slide-showcase-widget.php

------
https://chatgpt.com/codex/tasks/task_e_68e68b601db08325b7980b99c07e05e3