### PR TITLE
Remove view button configuration panels

### DIFF
--- a/includes/widgets/class-bw-slick-slider-widget.php
+++ b/includes/widgets/class-bw-slick-slider-widget.php
@@ -651,50 +651,6 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
 
         $this->end_controls_section();
 
-        $this->start_controls_section(
-            'section_view_buttons',
-            [
-                'label' => __( 'View Buttons', 'bw-elementor-widgets' ),
-                'tab'   => Controls_Manager::TAB_CONTENT,
-            ]
-        );
-
-        $this->add_control(
-            'view_buttons_enable',
-            [
-                'label'        => __( 'Enable Buttons', 'bw-elementor-widgets' ),
-                'type'         => Controls_Manager::SWITCHER,
-                'label_on'     => __( 'On', 'bw-elementor-widgets' ),
-                'label_off'    => __( 'Off', 'bw-elementor-widgets' ),
-                'return_value' => 'yes',
-                'default'      => 'yes',
-            ]
-        );
-
-        $this->add_responsive_control(
-            'view_buttons_padding',
-            [
-                'label'      => __( 'Buttons Padding', 'bw-elementor-widgets' ),
-                'type'       => Controls_Manager::DIMENSIONS,
-                'size_units' => [ 'px', 'em', '%' ],
-                'default'    => [
-                    'top'    => 16,
-                    'right'  => 16,
-                    'bottom' => 16,
-                    'left'   => 16,
-                    'unit'   => 'px',
-                ],
-                'selectors'  => [
-                    '{{WRAPPER}} .bw-ss__overlay' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
-                ],
-                'condition'  => [
-                    'view_buttons_enable' => 'yes',
-                ],
-            ]
-        );
-
-        $this->end_controls_section();
-
         $this->start_controls_section( 'overlay_buttons_section', [
             'label' => __( 'Overlay Buttons', 'bw-elementor-widgets' ),
             'tab'   => Controls_Manager::TAB_STYLE,
@@ -703,12 +659,9 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
         $this->add_group_control( Group_Control_Typography::get_type(), [
             'name'      => 'overlay_buttons_typography',
             'selector'  => '{{WRAPPER}} .bw-slick-slider .bw-ss__btn',
-            'condition' => [ 'view_buttons_enable' => 'yes' ],
         ] );
 
-        $this->start_controls_tabs( 'overlay_buttons_color_tabs', [
-            'condition' => [ 'view_buttons_enable' => 'yes' ],
-        ] );
+        $this->start_controls_tabs( 'overlay_buttons_color_tabs' );
 
         $this->start_controls_tab( 'overlay_buttons_color_normal', [
             'label' => __( 'Normal', 'bw-elementor-widgets' ),
@@ -769,7 +722,6 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
             'selectors' => [
                 '{{WRAPPER}} .bw-slick-slider' => '--bw-overlay-buttons-radius: {{SIZE}}{{UNIT}};',
             ],
-            'condition' => [ 'view_buttons_enable' => 'yes' ],
         ] );
 
         $this->add_responsive_control( 'overlay_buttons_padding_vertical', [
@@ -781,7 +733,6 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
             'selectors' => [
                 '{{WRAPPER}} .bw-slick-slider' => '--bw-overlay-buttons-padding-y: {{SIZE}}{{UNIT}};',
             ],
-            'condition' => [ 'view_buttons_enable' => 'yes' ],
         ] );
 
         $this->add_responsive_control( 'overlay_buttons_padding_horizontal', [
@@ -793,7 +744,6 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
             'selectors' => [
                 '{{WRAPPER}} .bw-slick-slider' => '--bw-overlay-buttons-padding-x: {{SIZE}}{{UNIT}};',
             ],
-            'condition' => [ 'view_buttons_enable' => 'yes' ],
         ] );
 
         $this->end_controls_section();
@@ -801,9 +751,6 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
 
     protected function render() {
         $settings            = $this->get_settings_for_display();
-        $view_buttons_enabled = isset( $settings['view_buttons_enable'] )
-            ? ( 'yes' === $settings['view_buttons_enable'] )
-            : ( isset( $settings['overlay_buttons_enable'] ) ? 'yes' === $settings['overlay_buttons_enable'] : true );
         $content_type        = isset( $settings['content_type'] ) ? sanitize_key( $settings['content_type'] ) : 'post';
         $available_post_types = $this->get_post_type_options();
         if ( empty( $available_post_types ) ) {
@@ -990,7 +937,7 @@ class Widget_Bw_Slick_Slider extends Widget_Base {
                                 <?php else : ?>
                                     <span class="bw-slick-item__image-placeholder" aria-hidden="true"></span>
                                 <?php endif; ?>
-                                <?php if ( $thumbnail_html && $view_buttons_enabled ) : ?>
+                                <?php if ( $thumbnail_html ) : ?>
                                     <div class="overlay-buttons bw-ss__overlay has-buttons">
                                         <div class="bw-ss__buttons<?php echo $has_add_to_cart ? ' bw-ss__buttons--double' : ''; ?>">
                                             <a class="overlay-button overlay-button--view bw-ss__btn bw-view-btn" href="<?php echo esc_url( $permalink ); ?>">

--- a/includes/widgets/class-bw-slide-showcase-widget.php
+++ b/includes/widgets/class-bw-slide-showcase-widget.php
@@ -39,7 +39,6 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
         $this->register_layout_controls();
         $this->register_image_controls();
         $this->register_slider_controls();
-        $this->register_button_controls();
         $this->register_style_controls();
     }
 
@@ -147,19 +146,6 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
                 'px' => [ 'min' => 0, 'max' => 120, 'step' => 1 ],
             ],
             'default' => [ 'size' => 24, 'unit' => 'px' ],
-        ] );
-
-        $this->add_responsive_control( 'side_padding', [
-            'label'      => __( 'Side Padding', 'bw-elementor-widgets' ),
-            'type'       => Controls_Manager::DIMENSIONS,
-            'allowed_dimensions' => [ 'left', 'right' ],
-            'size_units' => [ 'px', '%', 'em' ],
-            'default'    => [
-                'left' => 50,
-                'right' => 50,
-                'unit' => 'px',
-                'isLinked' => false,
-            ],
         ] );
 
         $this->end_controls_section();
@@ -362,126 +348,6 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
             'fields'      => $repeater->get_controls(),
             'title_field' => __( 'Breakpoint: {{{ breakpoint }}}px', 'bw-elementor-widgets' ),
         ] );
-
-        $this->end_controls_section();
-    }
-
-    private function register_button_controls() {
-        $this->start_controls_section( 'view_button_section', [
-            'label' => __( 'View Buttons', 'bw-elementor-widgets' ),
-        ] );
-
-        $this->add_control( 'view_button_text', [
-            'label'       => __( 'Testo bottone', 'bw-elementor-widgets' ),
-            'type'        => Controls_Manager::TEXT,
-            'default'     => __( 'View Collection', 'bw-elementor-widgets' ),
-            'placeholder' => __( 'View Collection', 'bw-elementor-widgets' ),
-        ] );
-
-        $this->add_control(
-            'button_color',
-            [
-                'label'   => __( 'Colore principale pulsante', 'bw' ),
-                'type'    => Controls_Manager::COLOR,
-                'default' => '#80FD03',
-                'selectors' => [
-                    '{{WRAPPER}}' => '--btn-bg: {{VALUE}}; --arrow-bg: {{VALUE}};',
-                ],
-            ]
-        );
-
-        $this->add_control(
-            'button_text_color',
-            [
-                'label'   => __( 'Colore testo pulsante', 'bw' ),
-                'type'    => Controls_Manager::COLOR,
-                'default' => '#000000',
-                'selectors' => [
-                    '{{WRAPPER}}' => '--btn-color: {{VALUE}};',
-                ],
-            ]
-        );
-
-        $this->add_control(
-            'button_border_color',
-            [
-                'label'   => __( 'Colore bordo pulsante', 'bw' ),
-                'type'    => Controls_Manager::COLOR,
-                'default' => '#000000',
-                'selectors' => [
-                    '{{WRAPPER}}' => '--btn-border-color: {{VALUE}}; --arrow-border-color: {{VALUE}};',
-                ],
-            ]
-        );
-
-        $this->add_responsive_control(
-            'button_border_width',
-            [
-                'label' => __( 'Spessore bordo (px)', 'bw' ),
-                'type'  => Controls_Manager::SLIDER,
-                'size_units' => [ 'px' ],
-                'range' => [
-                    'px' => [ 'min' => 0, 'max' => 10 ],
-                ],
-                'default' => [ 'size' => 1, 'unit' => 'px' ],
-                'selectors' => [
-                    '{{WRAPPER}}' => '--btn-border-width: {{SIZE}}{{UNIT}}; --arrow-border-width: {{SIZE}}{{UNIT}};',
-                ],
-            ]
-        );
-
-        $this->add_responsive_control(
-            'arrow_margin',
-            [
-                'label' => __( 'Margini sfera freccia', 'bw' ),
-                'type'  => Controls_Manager::DIMENSIONS,
-                'size_units' => [ 'px', '%' ],
-                'default' => [
-                    'top' => 0,
-                    'right' => 0,
-                    'bottom' => 0,
-                    'left' => 0,
-                    'unit' => 'px',
-                    'isLinked' => true,
-                ],
-                'selectors' => [
-                    '{{WRAPPER}}' => '--arrow-margin: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
-                ],
-            ]
-        );
-
-        $this->add_responsive_control(
-            'arrow_size',
-            [
-                'label' => __( 'Dimensione sfera freccia', 'bw' ),
-                'type'  => Controls_Manager::SLIDER,
-                'range' => [ 'px' => [ 'min' => 20, 'max' => 100 ] ],
-                'default' => [ 'size' => 46, 'unit' => 'px' ],
-                'selectors' => [
-                    '{{WRAPPER}}' => '--arrow-size: {{SIZE}}{{UNIT}};',
-                ],
-            ]
-        );
-
-        $this->add_responsive_control(
-            'button_padding',
-            [
-                'label' => __( 'Padding pulsante testo', 'bw' ),
-                'type'  => Controls_Manager::DIMENSIONS,
-                'size_units' => [ 'px' ],
-                'default' => [
-                    'top' => 14,
-                    'right' => 32,
-                    'bottom' => 14,
-                    'left' => 32,
-                    'unit' => 'px',
-                    'isLinked' => false,
-                ],
-                'selectors' => [
-                    '{{WRAPPER}}' => '--btn-padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};',
-                ],
-            ]
-        );
 
         $this->end_controls_section();
     }
@@ -909,17 +775,8 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
         $query = new \WP_Query( $query_args );
 
         $border_radius_value = $this->format_dimensions( isset( $settings['border_radius'] ) ? $settings['border_radius'] : [] );
-        $side_padding_value  = $this->format_side_padding( isset( $settings['side_padding'] ) ? $settings['side_padding'] : [] );
-        $content_style_parts = [];
-
-        $base_content_style = $this->build_content_style( $side_padding_value );
-        if ( $base_content_style ) {
-            $content_style_parts[] = $base_content_style;
-        }
-
-        $content_style = trim( implode( ' ', $content_style_parts ) );
         $object_fit          = $image_crop ? 'cover' : 'contain';
-        $button_text         = ! empty( $settings['view_button_text'] ) ? $settings['view_button_text'] : __( 'View Collection', 'bw-elementor-widgets' );
+        $button_text         = __( 'View Collection', 'bw-elementor-widgets' );
         ?>
         <div
             class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $wrapper_classes ) ) ); ?>"
@@ -974,7 +831,7 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
                                     <img src="<?php echo esc_url( $image_url ); ?>" alt="<?php echo esc_attr( $title ); ?>" class="bw-slide-showcase-image" style="<?php echo $this->build_image_style( $image_height, $object_fit ); ?>">
                                 <?php endif; ?>
                             </div>
-                            <div class="bw-slide-showcase-content content"<?php echo $content_style ? ' style="' . esc_attr( $content_style ) . '"' : ''; ?>>
+                            <div class="bw-slide-showcase-content content">
                                 <div class="bw-slide-showcase-title-section">
                                     <h1><?php echo esc_html( $title ); ?></h1>
                                     <?php if ( $subtitle ) : ?>
@@ -1268,36 +1125,6 @@ class Widget_Bw_Slide_Showcase extends Widget_Base {
         }
 
         return trim( sprintf( '%s %s %s %s', $top, $right, $bottom, $left ) );
-    }
-
-    private function format_side_padding( $dimensions ) {
-        if ( empty( $dimensions ) || ! is_array( $dimensions ) ) {
-            return '';
-        }
-
-        $unit = $this->sanitize_dimension_unit( isset( $dimensions['unit'] ) ? $dimensions['unit'] : '' );
-        $left = isset( $dimensions['left'] ) && '' !== $dimensions['left'] ? $dimensions['left'] . $unit : '';
-        $right = isset( $dimensions['right'] ) && '' !== $dimensions['right'] ? $dimensions['right'] . $unit : '';
-
-        $styles = [];
-        if ( $left ) {
-            $styles[] = 'padding-left: ' . $left . ';';
-        }
-        if ( $right ) {
-            $styles[] = 'padding-right: ' . $right . ';';
-        }
-
-        return implode( ' ', $styles );
-    }
-
-    private function build_content_style( $side_padding ) {
-        $styles = [];
-
-        if ( $side_padding ) {
-            $styles[] = trim( $side_padding );
-        }
-
-        return implode( ' ', $styles );
     }
 
     private function build_image_style( $image_height, $object_fit ) {


### PR DESCRIPTION
## Summary
- remove the View Buttons control section from both Elementor widgets
- simplify the slide showcase defaults by dropping the side padding option and relying on a fixed button label
- keep overlay styling controls available without conditional dependencies

## Testing
- php -l includes/widgets/class-bw-slide-showcase-widget.php
- php -l includes/widgets/class-bw-slick-slider-widget.php

------
https://chatgpt.com/codex/tasks/task_e_68e69233b4c483259e2775b55f4e05f2