### PR TITLE
Fix filter selection state not reflected on search results page load

### DIFF
--- a/assets/css/bw-search-surface.css
+++ b/assets/css/bw-search-surface.css
@@ -32,10 +32,21 @@
     margin: 0;
 }
 
-/* ── Active chips strip (server-rendered remove-filter links) ── */
-.bw-search-results-page .bw-fpw-active-chips {
+/* ── Active chips strip (server-rendered remove-filter links)
+       Navigation links for query/scope/advanced filters.
+       Not targeted by JS (no bw-fpw-active-chips class), so these persist
+       as permanent navigation shortcuts above the product grid toolbar. ── */
+.bw-search-results-page .bw-search-results-page__chips {
     padding: 12px 40px 0;
     box-sizing: border-box;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+}
+
+.bw-search-results-page .bw-search-results-page__chips:empty {
+    display: none;
 }
 
 /* ── Bring the product grid wrapper flush so it respects its own

--- a/includes/modules/search-surface/runtime/headless-product-grid-renderer.php
+++ b/includes/modules/search-surface/runtime/headless-product-grid-renderer.php
@@ -105,6 +105,8 @@ function bw_ss_build_headless_product_grid_request( $state, $settings, $page = n
             'post_type'       => $settings['post_type'],
             'context_slug'    => $state['context_slug'],
             'category'        => $state['category'],
+            'subcategories'   => isset( $state['subcategories'] ) ? (array) $state['subcategories'] : [],
+            'tags'            => isset( $state['tags'] ) ? (array) $state['tags'] : [],
             'search_enabled'  => 'yes',
             'search'          => $state['query'],
             'author'          => $advanced_author,
@@ -164,8 +166,8 @@ function bw_ss_build_headless_discovery_bootstrap_payload( $state, $settings, $u
         'selected'             => [
             'category'      => $state['category'],
             'search'        => $state['query'],
-            'subcategories' => [],
-            'tags'          => [],
+            'subcategories' => isset( $state['subcategories'] ) ? array_values( array_filter( array_map( 'absint', (array) $state['subcategories'] ) ) ) : [],
+            'tags'          => isset( $state['tags'] ) ? array_values( array_filter( array_map( 'absint', (array) $state['tags'] ) ) ) : [],
             'year'          => [ 'from' => null, 'to' => null ],
             'advanced'      => [
                 'artist'    => [],
@@ -407,7 +409,7 @@ function bw_ss_render_headless_product_grid( $args = [] ) {
     ?>
     <div class="bw-product-grid-wrapper bw-fpw-layout-top bw-search-results-grid-wrapper" data-filter-breakpoint="<?php echo esc_attr( $settings['responsive_filter_breakpoint'] ); ?>" data-responsive-filter-mode="<?php echo esc_attr( $settings['responsive_filter_mode'] ? 'yes' : 'no' ); ?>" data-drawer-side="<?php echo esc_attr( $settings['drawer_side'] ); ?>">
         <div class="bw-search-results-page__header">
-            <div class="bw-search-results-page__chips bw-fpw-active-chips" data-widget-id="<?php echo esc_attr( $widget_id ); ?>">
+            <div class="bw-search-results-page__chips" data-widget-id="<?php echo esc_attr( $widget_id ); ?>">
                 <?php bw_ss_render_initial_active_chips_markup( $active_chips ); ?>
             </div>
         </div>

--- a/includes/modules/search-surface/runtime/url-state.php
+++ b/includes/modules/search-surface/runtime/url-state.php
@@ -104,22 +104,38 @@ function bw_ss_get_current_query_args() {
     return $query_args;
 }
 
+function bw_ss_normalize_int_array_from_url( $raw_value, $max = 50 ) {
+    $raw   = is_array( $raw_value ) ? $raw_value : [];
+    $clean = [];
+
+    foreach ( $raw as $v ) {
+        $id = absint( $v );
+        if ( $id > 0 ) {
+            $clean[] = $id;
+        }
+    }
+
+    return array_values( array_unique( array_slice( $clean, 0, $max ) ) );
+}
+
 function bw_ss_build_search_results_state_from_url() {
-    $query_args = bw_ss_get_current_query_args();
-    $scope      = bw_ss_normalize_scope_param( isset( $query_args['scope'] ) ? $query_args['scope'] : '' );
-    $search     = function_exists( 'bw_fpw_normalize_search_query' )
+    $query_args    = bw_ss_get_current_query_args();
+    $scope         = bw_ss_normalize_scope_param( isset( $query_args['scope'] ) ? $query_args['scope'] : '' );
+    $search        = function_exists( 'bw_fpw_normalize_search_query' )
         ? bw_fpw_normalize_search_query( isset( $query_args['q'] ) ? $query_args['q'] : '' )
         : sanitize_text_field( (string) ( $query_args['q'] ?? '' ) );
-    $page       = function_exists( 'bw_fpw_normalize_positive_int' )
+    $page          = function_exists( 'bw_fpw_normalize_positive_int' )
         ? bw_fpw_normalize_positive_int( isset( $query_args['page'] ) ? $query_args['page'] : 1, 1, 1, 1000 )
         : max( 1, absint( $query_args['page'] ?? 1 ) );
-    $author     = function_exists( 'bw_fpw_extract_filter_tokens_from_value' )
+    $author        = function_exists( 'bw_fpw_extract_filter_tokens_from_value' )
         ? bw_fpw_extract_filter_tokens_from_value( $query_args['author'] ?? [] )
         : [];
-    $source     = function_exists( 'bw_fpw_extract_filter_tokens_from_value' )
+    $source        = function_exists( 'bw_fpw_extract_filter_tokens_from_value' )
         ? bw_fpw_extract_filter_tokens_from_value( $query_args['source'] ?? [] )
         : [];
-    $category   = bw_ss_get_scope_default_category( $scope );
+    $category      = bw_ss_get_scope_default_category( $scope );
+    $subcategories = bw_ss_normalize_int_array_from_url( $query_args['subcategories'] ?? [] );
+    $tags          = bw_ss_normalize_int_array_from_url( $query_args['tags'] ?? [] );
 
     return [
         'query'         => $search,
@@ -128,6 +144,8 @@ function bw_ss_build_search_results_state_from_url() {
         'context_slug'  => bw_ss_get_scope_context_slug( $scope ),
         'page'          => $page,
         'category'      => $category,
+        'subcategories' => $subcategories,
+        'tags'          => $tags,
         'advanced'      => [
             'author' => $author,
             'source' => $source,


### PR DESCRIPTION
Three-part fix for the bug where subcategory and tag selections were never shown as active in the visible filter buttons on page load:

1. url-state.php: parse subcategories[] and tags[] from URL query params into $state, with a dedicated bw_ss_normalize_int_array_from_url() helper that sanitises and deduplicates the values.

2. headless-product-grid-renderer.php: two fixes —
   - bw_ss_build_headless_discovery_bootstrap_payload(): selected.subcategories and selected.tags were hardcoded to [] regardless of $state; now populated from $state so hydrateDiscoveryStateFromBootstrap() in JS correctly sets state.subcategories / state.tags on page load, causing the "Categories ▾" and "Style/Subject ▾" visible filter buttons to render with is-selected when pre-selected via URL.
   - bw_ss_build_headless_product_grid_request(): pass subcategories and tags from $state to the engine so the server-rendered initial results are already filtered correctly.

3. headless-product-grid-renderer.php + bw-search-surface.css: removed the bw-fpw-active-chips class from the PHP chips header container so JS no longer clears it, preventing the query/scope navigation chips from flashing away on load. Updated the CSS selector accordingly and added flex layout + :empty { display:none } to the chips strip.

https://claude.ai/code/session_01T1LtdM16jeUa7qYmS2t7uw