### PR TITLE
Fix ?category=slug filter state not reflected in search results UI

### DIFF
--- a/includes/modules/search-engine/engine/query-planner.php
+++ b/includes/modules/search-engine/engine/query-planner.php
@@ -104,6 +104,14 @@ function bw_fpw_build_tax_query($post_type, $category = 'all', $subcategories = 
                 'terms' => [absint($category)],
             ];
         }
+    } elseif (!empty($subcategories)) {
+        // category = 'all' with explicit subcategory IDs: filter directly by those term IDs.
+        // Used by the search surface when ?category=<slug> maps to a subcategory selection.
+        $tax_query[] = [
+            'taxonomy' => $taxonomy,
+            'field' => 'term_id',
+            'terms' => $subcategories,
+        ];
     }
 
     if (!empty($tags)) {

--- a/includes/modules/search-surface/runtime/headless-product-grid-renderer.php
+++ b/includes/modules/search-surface/runtime/headless-product-grid-renderer.php
@@ -34,6 +34,10 @@ function bw_ss_state_has_active_filters( $state ) {
         return true;
     }
 
+    if ( ! empty( $state['subcategories'] ) ) {
+        return true;
+    }
+
     if ( ! empty( $state['tags'] ) ) {
         return true;
     }

--- a/includes/modules/search-surface/runtime/url-state.php
+++ b/includes/modules/search-surface/runtime/url-state.php
@@ -385,8 +385,19 @@ function bw_ss_build_search_results_state_from_url() {
     $publisher        = bw_ss_resolve_advanced_filter_tokens_from_query( 'publisher', $query_args['publisher'] ?? [], $scope );
     $source           = bw_ss_resolve_advanced_filter_tokens_from_query( 'source', $query_args['source'] ?? [], $scope );
     $technique        = bw_ss_resolve_advanced_filter_tokens_from_query( 'technique', $query_args['technique'] ?? [], $scope );
-    $category         = $category_term instanceof WP_Term ? (int) $category_term->term_id : $default_category;
-    $subcategories    = bw_ss_normalize_int_array_from_url( $query_args['subcategories'] ?? [] );
+
+    // When ?category=<slug> is in the URL keep the scope default as the parent so the
+    // Categories dropdown loads sibling categories rather than children of the clicked term.
+    // The resolved term is treated as a selected subcategory so the JS filter button lights
+    // up and the engine (via the new 'all'+subcategories branch) filters results correctly.
+    $url_subcategory_ids = bw_ss_normalize_int_array_from_url( $query_args['subcategories'] ?? [] );
+    if ( $category_term instanceof WP_Term ) {
+        $category      = $default_category;
+        $subcategories = array_values( array_unique( array_merge( [ (int) $category_term->term_id ], $url_subcategory_ids ) ) );
+    } else {
+        $category      = $default_category;
+        $subcategories = $url_subcategory_ids;
+    }
 
     return [
         'query'         => $search,


### PR DESCRIPTION
Three coordinated changes:

1. query-planner: extend bw_fpw_build_tax_query with an elseif branch for category='all' + non-empty subcategories, so the engine actually filters when the search surface uses the scope-default parent category.

2. url-state: when ?category=<slug> is present, keep $category as the scope default ('all' for scope=all) and move the resolved term ID into $subcategories. This makes the bootstrap payload carry the term in selected.subcategories, which the JS uses to highlight the "Categories" filter button and mark it as selected in the dropdown.

3. headless-product-grid-renderer: add a subcategories check to bw_ss_state_has_active_filters so the "Reset Filters" button appears when a category is pre-selected via URL even though $category is now always the scope default.