### PR TITLE
Fix mobile nav overlay dim, hamburger speed, and glass blur effect

### DIFF
--- a/includes/modules/header/assets/css/bw-navigation.css
+++ b/includes/modules/header/assets/css/bw-navigation.css
@@ -144,6 +144,7 @@
     -webkit-appearance: none;
     appearance: none;
     cursor: pointer;
+    touch-action: manipulation;
     transition: color 0.25s ease;
 }
 
@@ -177,31 +178,21 @@
     position: fixed;
     inset: 0;
     z-index: 99999;
-    display: flex;
-    justify-content: flex-start;
-    align-items: flex-start;
-    padding: clamp(12px, 1.6vw, 16px);
-    background: rgba(0, 0, 0, 0.06);
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
-    opacity: 0;
-    visibility: hidden;
+    background: transparent;
     pointer-events: none;
-    transition: opacity 0.18s ease, visibility 0s linear 0.18s;
-    will-change: opacity;
+    visibility: hidden;
 }
 
 .bw-navigation__mobile-overlay.is-open {
-    opacity: 1;
-    visibility: visible;
     pointer-events: auto;
+    visibility: visible;
 }
 
 .bw-navigation__popup-panel {
     box-sizing: border-box;
     opacity: 0;
     transform: translateY(8px);
-    transition: opacity 0.15s ease, transform 0.15s ease;
+    transition: opacity 0.08s ease, transform 0.08s ease;
     will-change: opacity, transform;
     visibility: hidden;
     pointer-events: none;
@@ -209,7 +200,6 @@
     flex-direction: column;
 }
 
-.bw-navigation__mobile-overlay.is-open .bw-navigation__mobile-panel,
 .bw-navigation__mobile-panel {
     position: fixed;
     top: var(--bw-navigation-popup-top, 72px);
@@ -217,9 +207,10 @@
     width: min(var(--bw-navigation-popup-width, 290px), calc(100vw - 24px));
     max-height: min(var(--bw-navigation-popup-max-height, 80vh), 720px);
     transform-origin: var(--bw-navigation-popup-transform-origin, top left);
+    z-index: 100000;
 }
 
-.bw-navigation__mobile-overlay.is-open .bw-navigation__mobile-panel {
+.bw-navigation__mobile-panel.is-open {
     opacity: 1;
     transform: translateY(0);
     visibility: visible;
@@ -243,9 +234,9 @@
 }
 
 .bw-navigation__account-dropdown-panel {
-    position: absolute;
-    top: calc(100% + 12px);
-    right: 0;
+    position: fixed;
+    top: var(--bw-account-dropdown-top, 72px);
+    right: var(--bw-account-dropdown-right, 12px);
     left: auto;
     width: min(348px, calc(100vw - 24px));
     min-width: 295px;
@@ -254,7 +245,7 @@
     transform-origin: top right;
 }
 
-.bw-navigation__account-dropdown.is-open .bw-navigation__account-dropdown-panel {
+.bw-navigation__account-dropdown-panel.is-open {
     opacity: 1;
     transform: translateY(0);
     visibility: visible;
@@ -700,9 +691,9 @@
     display: inline-flex;
 }
 
-.bw-navigation__mobile-overlay .bw-navigation__mobile-footer .bw-navigation__mobile-footer-link,
-.bw-navigation__mobile-overlay .bw-navigation__mobile-footer .bw-navigation__mobile-footer-link:link,
-.bw-navigation__mobile-overlay .bw-navigation__mobile-footer .bw-navigation__mobile-footer-link:visited {
+.bw-navigation__mobile-panel .bw-navigation__mobile-footer .bw-navigation__mobile-footer-link,
+.bw-navigation__mobile-panel .bw-navigation__mobile-footer .bw-navigation__mobile-footer-link:link,
+.bw-navigation__mobile-panel .bw-navigation__mobile-footer .bw-navigation__mobile-footer-link:visited {
     color: #9b9d9d !important;
     text-decoration: none;
     font-size: 12px;
@@ -711,9 +702,9 @@
     transition: color 0.15s ease, opacity 0.15s ease;
 }
 
-.bw-navigation__mobile-overlay .bw-navigation__mobile-footer .bw-navigation__mobile-footer-link:hover,
-.bw-navigation__mobile-overlay .bw-navigation__mobile-footer .bw-navigation__mobile-footer-link:focus-visible,
-.bw-navigation__mobile-overlay .bw-navigation__mobile-footer .bw-navigation__mobile-footer-link:active {
+.bw-navigation__mobile-panel .bw-navigation__mobile-footer .bw-navigation__mobile-footer-link:hover,
+.bw-navigation__mobile-panel .bw-navigation__mobile-footer .bw-navigation__mobile-footer-link:focus-visible,
+.bw-navigation__mobile-panel .bw-navigation__mobile-footer .bw-navigation__mobile-footer-link:active {
     color: #fafafa !important;
 }
 
@@ -748,10 +739,6 @@
     .bw-navigation__mobile-panel {
         width: min(var(--bw-navigation-popup-width, 290px), calc(100vw - 24px));
         border-radius: 18px;
-    }
-
-    .bw-navigation__mobile-overlay {
-        padding: 12px;
     }
 
     .bw-navigation__mobile-content {

--- a/includes/modules/header/assets/js/bw-account-dropdown.js
+++ b/includes/modules/header/assets/js/bw-account-dropdown.js
@@ -8,9 +8,12 @@
         this.breakpoint = parseInt(root.getAttribute('data-bw-account-dropdown-breakpoint'), 10)
             || ((window.bwHeaderConfig && window.bwHeaderConfig.breakpoint) ? parseInt(window.bwHeaderConfig.breakpoint, 10) : 1024);
         this.isDesktop = window.innerWidth > this.breakpoint;
+        this._closeTimeout = null;
 
         this.handlePointerEnter = this.handlePointerEnter.bind(this);
         this.handlePointerLeave = this.handlePointerLeave.bind(this);
+        this.handlePanelPointerEnter = this.handlePanelPointerEnter.bind(this);
+        this.handlePanelPointerLeave = this.handlePanelPointerLeave.bind(this);
         this.handleFocusIn = this.handleFocusIn.bind(this);
         this.handleFocusOut = this.handleFocusOut.bind(this);
         this.handleTriggerClick = this.handleTriggerClick.bind(this);
@@ -20,12 +23,24 @@
     }
 
     BWAccountDropdown.prototype.init = function () {
-        if (!this.root || !this.trigger || !this.panel || !this.isDesktop) {
+        if (!this.root || !this.trigger || !this.panel) {
+            return;
+        }
+
+        // Move panel to <body> so its backdrop-filter samples real page content
+        // instead of being trapped inside the header's compositor layer.
+        if (this.panel.parentNode !== document.body) {
+            document.body.appendChild(this.panel);
+        }
+
+        if (!this.isDesktop) {
             return;
         }
 
         this.root.addEventListener('pointerenter', this.handlePointerEnter);
         this.root.addEventListener('pointerleave', this.handlePointerLeave);
+        this.panel.addEventListener('pointerenter', this.handlePanelPointerEnter);
+        this.panel.addEventListener('pointerleave', this.handlePanelPointerLeave);
         this.root.addEventListener('focusin', this.handleFocusIn);
         this.root.addEventListener('focusout', this.handleFocusOut);
         this.trigger.addEventListener('click', this.handleTriggerClick);
@@ -34,18 +49,51 @@
         window.addEventListener('resize', this.handleWindowResize);
     };
 
+    BWAccountDropdown.prototype.positionPanel = function () {
+        if (!this.trigger || !this.panel) {
+            return;
+        }
+
+        var rect = this.trigger.getBoundingClientRect();
+        var viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+        var gap = 10;
+        var margin = 12;
+        var top = Math.round(rect.bottom + gap);
+        // Align panel's right edge with trigger's right edge
+        var right = Math.round(viewportWidth - rect.right);
+        if (right < margin) {
+            right = margin;
+        }
+
+        this.panel.style.setProperty('--bw-account-dropdown-top', top + 'px');
+        this.panel.style.setProperty('--bw-account-dropdown-right', right + 'px');
+    };
+
     BWAccountDropdown.prototype.open = function () {
         if (!this.isDesktop) {
             return;
         }
 
+        if (this._closeTimeout) {
+            clearTimeout(this._closeTimeout);
+            this._closeTimeout = null;
+        }
+
+        this.positionPanel();
         this.root.classList.add('is-open');
+        this.panel.classList.add('is-open');
         this.trigger.setAttribute('aria-expanded', 'true');
         this.panel.setAttribute('aria-hidden', 'false');
     };
 
     BWAccountDropdown.prototype.close = function () {
+        if (this._closeTimeout) {
+            clearTimeout(this._closeTimeout);
+            this._closeTimeout = null;
+        }
+
         this.root.classList.remove('is-open');
+        this.panel.classList.remove('is-open');
         this.trigger.setAttribute('aria-expanded', 'false');
         this.panel.setAttribute('aria-hidden', 'true');
     };
@@ -55,6 +103,22 @@
     };
 
     BWAccountDropdown.prototype.handlePointerLeave = function () {
+        var self = this;
+        // Delay close so the pointer has time to reach the panel before it disappears.
+        this._closeTimeout = setTimeout(function () {
+            self.close();
+        }, 120);
+    };
+
+    BWAccountDropdown.prototype.handlePanelPointerEnter = function () {
+        // Cancel any pending close when the pointer enters the panel.
+        if (this._closeTimeout) {
+            clearTimeout(this._closeTimeout);
+            this._closeTimeout = null;
+        }
+    };
+
+    BWAccountDropdown.prototype.handlePanelPointerLeave = function () {
         this.close();
     };
 
@@ -68,7 +132,7 @@
         }
 
         event.preventDefault();
-        if (this.root.classList.contains('is-open')) {
+        if (this.panel.classList.contains('is-open')) {
             this.close();
             return;
         }
@@ -78,7 +142,7 @@
 
     BWAccountDropdown.prototype.handleFocusOut = function (event) {
         var nextTarget = event.relatedTarget;
-        if (nextTarget && this.root.contains(nextTarget)) {
+        if (nextTarget && (this.root.contains(nextTarget) || this.panel.contains(nextTarget))) {
             return;
         }
 
@@ -86,7 +150,7 @@
     };
 
     BWAccountDropdown.prototype.handleDocumentClick = function (event) {
-        if (!this.root.contains(event.target)) {
+        if (!this.root.contains(event.target) && !this.panel.contains(event.target)) {
             this.close();
         }
     };
@@ -101,6 +165,8 @@
         var nowDesktop = window.innerWidth > this.breakpoint;
         if (!nowDesktop) {
             this.close();
+        } else if (this.panel.classList.contains('is-open')) {
+            this.positionPanel();
         }
         this.isDesktop = nowDesktop;
     };

--- a/includes/modules/header/assets/js/bw-navigation.js
+++ b/includes/modules/header/assets/js/bw-navigation.js
@@ -27,10 +27,14 @@
             return;
         }
 
-        // Move overlay to <body> so fixed positioning is viewport-based,
-        // not constrained by transformed header ancestors.
+        // Move overlay and panel to <body> as siblings. Fixed positioning is
+        // then viewport-based, and the panel's backdrop-filter samples real
+        // page content instead of being trapped in the overlay's compositor layer.
         if (this.overlay.parentNode !== document.body) {
             document.body.appendChild(this.overlay);
+        }
+        if (this.panel && this.panel.parentNode !== document.body) {
+            document.body.appendChild(this.panel);
         }
 
         this.toggle.addEventListener('click', this.handleToggleClick);
@@ -129,6 +133,9 @@
         this.overlay.classList.add('is-open');
         this.overlay.setAttribute('aria-hidden', 'false');
         this.toggle.setAttribute('aria-expanded', 'true');
+        if (this.panel) {
+            this.panel.classList.add('is-open');
+        }
 
         var focusables = this.getFocusableElements();
         if (focusables.length > 0) {
@@ -142,6 +149,9 @@
         this.overlay.classList.remove('is-open');
         this.overlay.setAttribute('aria-hidden', 'true');
         this.toggle.setAttribute('aria-expanded', 'false');
+        if (this.panel) {
+            this.panel.classList.remove('is-open');
+        }
 
         if (this.lastActiveElement && typeof this.lastActiveElement.focus === 'function') {
             this.lastActiveElement.focus();


### PR DESCRIPTION
- Remove overlay background tint (transparent) and will-change: opacity so the page is no longer dimmed when the popup opens
- Add touch-action: manipulation to toggle button to eliminate the 300ms tap delay on mobile browsers
- Speed up popup panel transition from 0.15s to 0.08s
- Move mobile nav panel and account dropdown panel to document.body as siblings (not children) of their respective overlays; backdrop-filter on a child cannot sample real page content when the parent is promoted to a GPU compositor layer — sibling panels are outside that boundary and render the glass blur correctly
- Account dropdown: add positionPanel() with getBoundingClientRect to anchor the fixed-position panel below the trigger; add timeout-based close delay so the pointer can travel from trigger to panel without the menu disappearing
- Update CSS open-state selectors from overlay-descendant form to direct panel.is-open class; fix footer link selectors to reference the panel instead of the overlay