### PR TITLE
Localise glass blur to panel area only, remove full-page overlay blur

### DIFF
--- a/includes/modules/header/assets/css/bw-navigation.css
+++ b/includes/modules/header/assets/css/bw-navigation.css
@@ -178,9 +178,7 @@
     position: fixed;
     inset: 0;
     z-index: 99999;
-    background: rgba(0, 0, 0, 0.04);
-    backdrop-filter: blur(12px) saturate(1.3);
-    -webkit-backdrop-filter: blur(12px) saturate(1.3);
+    background: transparent;
     pointer-events: none;
     visibility: hidden;
 }
@@ -292,17 +290,10 @@
     overflow: hidden;
 }
 
-/* Mobile nav panel: overlay provides the blur (cart popup pattern),
-   panel uses a plain dark background so the blurred page shows through. */
-.bw-navigation__mobile-popup-surface.bw-surface-glass {
-    background: rgba(15, 15, 15, 0.84) !important;
-    backdrop-filter: none !important;
-    -webkit-backdrop-filter: none !important;
-    border: var(--bw-surface-glass-border) !important;
-}
-
-/* Account dropdown has no full-screen overlay, so the panel
-   provides its own blur directly. */
+/* Both panels sit at body level (siblings to any overlay), so their
+   backdrop-filter samples real page content — blur is localised to
+   exactly the panel's own bounding box, not the whole page. */
+.bw-navigation__mobile-popup-surface.bw-surface-glass,
 .bw-navigation__account-dropdown-surface.bw-surface-glass {
     background: rgba(15, 15, 15, 0.78) !important;
     backdrop-filter: blur(20px) saturate(1.4) !important;


### PR DESCRIPTION
Backdrop-filter on the overlay blurred the entire viewport. The correct approach is to put backdrop-filter on the panel itself: since both panels are now body-level siblings (not children of a compositor-layer ancestor), their backdrop-filter samples only the page content directly behind each panel's bounding box — exactly the localised glass look needed.

Overlay returns to fully transparent. Both surfaces use rgba(15,15,15,0.78)
+ blur(20px) saturate(1.4), matching the desired effect.