### PR TITLE
Refine mobile nav popup visual style to match reference design

### DIFF
--- a/includes/modules/header/assets/css/bw-navigation.css
+++ b/includes/modules/header/assets/css/bw-navigation.css
@@ -264,9 +264,9 @@
     flex: 1;
     min-height: 0;
     overflow: visible;
-    padding: 12px 12px 13px;
+    padding: 14px 14px 15px;
     background: transparent !important;
-    gap: 11px;
+    gap: 10px;
 }
 
 .bw-navigation__mobile-popup-surface .bw-navigation__mobile-content,
@@ -295,7 +295,7 @@
    exactly the panel's own bounding box, not the whole page. */
 .bw-navigation__mobile-popup-surface.bw-surface-glass,
 .bw-navigation__account-dropdown-surface.bw-surface-glass {
-    background: rgba(15, 15, 15, 0.78) !important;
+    background: rgba(30, 30, 34, 0.84) !important;
     backdrop-filter: blur(20px) saturate(1.4) !important;
     -webkit-backdrop-filter: blur(20px) saturate(1.4) !important;
     border: var(--bw-surface-glass-border) !important;
@@ -325,7 +325,8 @@
 }
 
 .bw-navigation__mobile-section--profile {
-    padding-top: 0;
+    padding-top: 4px;
+    border-top: 1px solid rgba(255, 255, 255, 0.09);
 }
 
 .bw-navigation__mobile-section--auth {
@@ -432,16 +433,16 @@
     min-width: 0;
     align-self: stretch;
     box-sizing: border-box;
-    min-height: 34px;
-    padding: 0 18px;
+    min-height: 48px;
+    padding: 0 22px;
     border-radius: 999px;
     background: #80fd03;
     color: #000000 !important;
     text-decoration: none;
-    font-size: 14px;
+    font-size: 16px;
     line-height: 1;
-    font-weight: 600;
-    letter-spacing: -0.01em;
+    font-weight: 700;
+    letter-spacing: -0.02em;
     white-space: nowrap;
     box-shadow: inset 0 0 0 1px #080808, 0 8px 18px rgba(0, 0, 0, 0.18);
     transition: opacity 0.15s ease, background-color 0.15s ease, transform 0.15s ease;
@@ -477,7 +478,7 @@
     justify-content: flex-start;
     width: 100%;
     max-width: 100%;
-    min-height: 34px;
+    min-height: 44px;
     padding: 0 18px;
     box-sizing: border-box;
     border: 1px solid rgba(255, 255, 255, 0.10);
@@ -485,7 +486,7 @@
     background: rgba(255, 255, 255, 0.10);
     color: #fafafa !important;
     text-decoration: none;
-    font-size: 14px;
+    font-size: 15px;
     line-height: 1;
     letter-spacing: -0.01em;
     font-weight: 600;
@@ -555,7 +556,7 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 7px;
+    gap: 3px;
 }
 
 .bw-navigation__mobile .menu-item {
@@ -595,14 +596,14 @@
     width: 100%;
     max-width: 100%;
     box-sizing: border-box;
-    min-height: 40px;
-    padding: 0 11px;
+    min-height: 48px;
+    padding: 0 14px;
     border: 1px solid transparent;
-    border-radius: 12px;
+    border-radius: 13px;
     background: transparent;
-    font-size: 16px;
+    font-size: 18px;
     line-height: 1.2;
-    letter-spacing: -0.01em;
+    letter-spacing: -0.02em;
     font-weight: 600;
     color: #fafafa !important;
     text-wrap: balance;
@@ -621,7 +622,7 @@
 .bw-navigation__mobile .current-menu-item > .bw-navigation__link,
 .bw-navigation__mobile .current-menu-parent > .bw-navigation__link,
 .bw-navigation__mobile .current-menu-ancestor > .bw-navigation__link {
-    background: transparent;
+    background: rgba(255, 255, 255, 0.08);
     border-color: transparent;
     box-shadow: none;
 }
@@ -742,17 +743,18 @@
     }
 
     .bw-navigation__mobile-content {
-        padding: 12px 12px 13px;
+        padding: 13px 13px 14px;
     }
 
     .bw-navigation__mobile .bw-navigation__link {
-        min-height: 44px;
-        padding: 0 12px;
-        border-radius: 15px;
+        min-height: 46px;
+        padding: 0 13px;
+        border-radius: 13px;
+        font-size: 17px;
     }
 
     .bw-navigation__mobile-section--profile {
-        padding-top: 0;
+        padding-top: 4px;
     }
 
     .bw-navigation__profile-card {


### PR DESCRIPTION
Panel: warmer dark bg rgba(30,30,34,0.84) instead of near-black
Content: padding 12px→14px, section gap 11px→10px

Nav items:
- min-height 40px→48px (46px on small phones)
- font-size 16px→18px (17px on small phones)
- letter-spacing -0.01em→-0.02em
- border-radius 12px→13px
- list gap 7px→3px (tighter, items are taller)
- current-menu-item: visible bg rgba(255,255,255,0.08) instead of transparent

CTA button:
- min-height 34px→48px
- font-size 14px→16px, font-weight 600→700
- letter-spacing -0.01em→-0.02em

Auth links: min-height 34px→44px, font-size 14px→15px

Profile section: border-top divider rgba(255,255,255,0.09) separating nav from profile/CTA area, matching reference section separators