### PR TITLE
Fix backdrop-filter blur on desktop filter and sort panels

### DIFF
--- a/assets/css/bw-product-grid.css
+++ b/assets/css/bw-product-grid.css
@@ -532,7 +532,6 @@ body.bw-fpw-drawer-no-scroll {
   row-gap: 16px;
   margin: 0 0 24px 0;
   transition: opacity 0.34s ease, transform 0.44s cubic-bezier(0.16, 1, 0.3, 1), visibility 0.34s ease;
-  will-change: opacity, transform;
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-toolbar[data-ui-ready="false"] {


### PR DESCRIPTION
Remove will-change: opacity, transform from .bw-fpw-discovery-toolbar. This property was promoting the toolbar to a permanent GPU compositing layer: backdrop-filter on descendant panels (sort menu and visible filter panel) could only sample that empty/transparent layer instead of the actual page content, making the glass blur invisible.

The transition property handles animations without a permanent layer.