### PR TITLE
Fix mobile nav: remove blue focus ring, add current-page indicator, s…

### DIFF
--- a/includes/modules/header/assets/css/bw-navigation.css
+++ b/includes/modules/header/assets/css/bw-navigation.css
@@ -599,6 +599,7 @@
     border: 1px solid transparent;
     border-radius: 12px;
     background: transparent;
+    outline: none;
     font-size: 16px;
     line-height: 1.2;
     letter-spacing: -0.01em;
@@ -617,7 +618,12 @@
     transform: translateY(-1px);
 }
 
-.bw-navigation__mobile .current-menu-item > .bw-navigation__link,
+.bw-navigation__mobile .current-menu-item > .bw-navigation__link {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(255, 255, 255, 0.18);
+    box-shadow: none;
+}
+
 .bw-navigation__mobile .current-menu-parent > .bw-navigation__link,
 .bw-navigation__mobile .current-menu-ancestor > .bw-navigation__link {
     background: transparent;

--- a/includes/modules/header/assets/js/bw-navigation.js
+++ b/includes/modules/header/assets/js/bw-navigation.js
@@ -37,6 +37,7 @@
             document.body.appendChild(this.panel);
         }
 
+        this.toggle.addEventListener('touchstart', this.handleToggleTouchStart, { passive: true });
         this.toggle.addEventListener('click', this.handleToggleClick);
         this.overlay.addEventListener('click', this.handleOverlayClick);
         document.addEventListener('keydown', this.handleDocumentKeydown);
@@ -129,7 +130,10 @@
     BWNavigation.prototype.open = function () {
         this.lastActiveElement = document.activeElement;
         this.scrollYOnOpen = window.pageYOffset || document.documentElement.scrollTop || 0;
-        this.positionPanel();
+        if (!this._prepositioned) {
+            this.positionPanel();
+        }
+        this._prepositioned = false;
         this.overlay.classList.add('is-open');
         this.overlay.setAttribute('aria-hidden', 'false');
         this.toggle.setAttribute('aria-expanded', 'true');
@@ -157,6 +161,14 @@
             this.lastActiveElement.focus();
         } else if (this.toggle && typeof this.toggle.focus === 'function') {
             this.toggle.focus();
+        }
+    };
+
+    BWNavigation.prototype.handleToggleTouchStart = function () {
+        // Pre-position the panel on first touch so open() fires with no reflow delay.
+        if (!this.overlay.classList.contains('is-open')) {
+            this._prepositioned = true;
+            this.positionPanel();
         }
     };
 


### PR DESCRIPTION
…peed up open

CSS:
- Add outline:none to .bw-navigation__mobile .bw-navigation__link to prevent the native browser focus ring (blue rounded rect on Safari/iOS) that appears when open() programmatically focuses the first menu item
- Split current-menu-* rules: only current-menu-item gets a visible indicator (subtle white bg + border), parent/ancestor selectors stay transparent so the highlight appears strictly on the current page's link

JS:
- Register touchstart on the toggle button to call positionPanel() eagerly (passive, no delay). When the click fires, positionPanel() is skipped via _prepositioned flag → the menu opens with zero reflow latency on touch