### PR TITLE
Fix Account visible on mobile: target cart specifically for touch target

### DIFF
--- a/includes/modules/header/assets/css/header-layout.css
+++ b/includes/modules/header/assets/css/header-layout.css
@@ -339,7 +339,7 @@ body.bw-has-sticky-header:not(.elementor-editor-active) .bw-header-spacer {
         min-height: 30px !important;
     }
 
-    .bw-custom-header .bw-navshop__item {
+    .bw-custom-header .bw-navshop__cart {
         display: inline-flex !important;
         align-items: center !important;
         justify-content: center !important;


### PR DESCRIPTION
Replaced .bw-navshop__item with .bw-navshop__cart in the mobile touch target rule. The generic .bw-navshop__item selector with display:inline-flex !important was overriding the inline CSS that hides .bw-navshop__account (injected via assets.php with display:none, no !important).