### PR TITLE
Fix mobile header: home selection, borders, panel glass

### DIFF
--- a/includes/modules/header/assets/css/bw-navigation.css
+++ b/includes/modules/header/assets/css/bw-navigation.css
@@ -298,7 +298,7 @@
     background: #171717d9 !important;
     backdrop-filter: blur(20px) saturate(1.4) !important;
     -webkit-backdrop-filter: blur(20px) saturate(1.4) !important;
-    border: var(--bw-surface-glass-border) !important;
+    border: none !important;
 }
 
 .bw-navigation__account-dropdown-surface .bw-navigation__mobile-content {
@@ -620,7 +620,7 @@
 
 .bw-navigation__mobile .current-menu-item > .bw-navigation__link {
     background: rgba(255, 255, 255, 0.08);
-    border-color: rgba(255, 255, 255, 0.18);
+    border-color: transparent;
     box-shadow: none;
 }
 

--- a/includes/modules/header/helpers/menu.php
+++ b/includes/modules/header/helpers/menu.php
@@ -3,6 +3,33 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+/**
+ * Remove current-menu-* classes from the home/front-page menu item
+ * when the current request is NOT the front page. WordPress sometimes
+ * incorrectly marks the Home item as current on WooCommerce archive
+ * pages or other pages where is_front_page() fires unexpectedly.
+ */
+if (!function_exists('bw_header_fix_home_current_class')) {
+    function bw_header_fix_home_current_class($classes, $item, $args, $depth)
+    {
+        if (is_front_page()) {
+            return $classes;
+        }
+        // Strip current-* classes from any item pointing to the front page URL.
+        if (isset($item->url) && rtrim($item->url, '/') === rtrim(home_url('/'), '/')) {
+            $classes = array_diff($classes, [
+                'current-menu-item',
+                'current-menu-parent',
+                'current-menu-ancestor',
+                'current_page_item',
+                'current_page_parent',
+                'current_page_ancestor',
+            ]);
+        }
+        return array_values($classes);
+    }
+}
+
 if (!function_exists('bw_header_filter_nav_link_class')) {
     function bw_header_filter_nav_link_class($atts)
     {
@@ -25,6 +52,7 @@ if (!function_exists('bw_header_render_menu')) {
         }
 
         add_filter('nav_menu_link_attributes', 'bw_header_filter_nav_link_class', 10, 1);
+        add_filter('nav_menu_css_class', 'bw_header_fix_home_current_class', 10, 4);
         $html = wp_nav_menu([
             'menu' => $menu_id,
             'menu_class' => $menu_class,
@@ -33,6 +61,7 @@ if (!function_exists('bw_header_render_menu')) {
             'echo' => false,
             'depth' => 2,
         ]);
+        remove_filter('nav_menu_css_class', 'bw_header_fix_home_current_class', 10);
         remove_filter('nav_menu_link_attributes', 'bw_header_filter_nav_link_class', 10);
 
         return is_string($html) ? $html : '';
@@ -48,6 +77,7 @@ if (!function_exists('bw_header_render_menu_location')) {
         }
 
         add_filter('nav_menu_link_attributes', 'bw_header_filter_nav_link_class', 10, 1);
+        add_filter('nav_menu_css_class', 'bw_header_fix_home_current_class', 10, 4);
         $html = wp_nav_menu([
             'theme_location' => $theme_location,
             'menu_class' => $menu_class,
@@ -56,6 +86,7 @@ if (!function_exists('bw_header_render_menu_location')) {
             'echo' => false,
             'depth' => 2,
         ]);
+        remove_filter('nav_menu_css_class', 'bw_header_fix_home_current_class', 10);
         remove_filter('nav_menu_link_attributes', 'bw_header_filter_nav_link_class', 10);
 
         return is_string($html) ? $html : '';


### PR DESCRIPTION
- Hook bw_header_fix_home_current_class filter around wp_nav_menu() calls in both bw_header_render_menu and bw_header_render_menu_location so the current-menu-* classes are stripped from the Home item on non-front-page requests
- Remove 1px border from active menu item link (border-color: transparent)
- Remove 1px border from the mobile panel surface (border: none)