### PR TITLE
Add Duplicate Page feature with full Elementor layout copy

### DIFF
--- a/blackwork-core-plugin.php
+++ b/blackwork-core-plugin.php
@@ -415,6 +415,11 @@ if (file_exists(plugin_dir_path(__FILE__) . 'includes/class-bw-redirects.php')) 
     require_once plugin_dir_path(__FILE__) . 'includes/class-bw-redirects.php';
 }
 
+// Duplicate page — adds a "Duplicate" row action to Pages and Posts
+if (is_admin() && file_exists(plugin_dir_path(__FILE__) . 'includes/class-bw-duplicate-page.php')) {
+    require_once plugin_dir_path(__FILE__) . 'includes/class-bw-duplicate-page.php';
+}
+
 
 // Includi il modulo BW Coming Soon
 if (file_exists(plugin_dir_path(__FILE__) . 'BW_coming_soon/bw-coming-soon.php')) {

--- a/docs/30-features/duplicate-page/duplicate-page.md
+++ b/docs/30-features/duplicate-page/duplicate-page.md
@@ -1,0 +1,106 @@
+# Duplicate Page — Feature Documentation
+
+## Overview
+
+The **Duplicate Page** feature adds a one-click "Duplicate" action to the WordPress admin page and post list screens. The copy preserves the complete WordPress post structure **and** the full Elementor layout, so the duplicated page opens in the Elementor editor exactly as the original was designed.
+
+## Entry point
+
+`includes/class-bw-duplicate-page.php` → `BW_Duplicate_Page` class  
+Loaded in `blackwork-core-plugin.php` (admin-only, wrapped in `is_admin()`).
+
+---
+
+## How it works
+
+### 1. Row action
+
+The class hooks into `page_row_actions` and `post_row_actions` to append a **Duplicate** link next to Edit / Quick Edit / Trash on every row.
+
+```
+Title ↑                              Link    Date ↑
+Documentation — Elementor            ✏ 🔗    …
+  Edit | Quick Edit | Trash | Duplicate | View
+```
+
+The link URL contains:
+- `action=bw_duplicate_page` (routed via `admin_action_bw_duplicate_page`)
+- `post={ID}` — source post ID
+- `_wpnonce={nonce}` — CSRF token scoped to the specific post
+
+### 2. Duplication process
+
+When the action fires:
+
+| Step | What happens |
+|---|---|
+| **Security** | Nonce verified (`bw_duplicate_page_{ID}`); capability check `edit_post` |
+| **Post insert** | `wp_insert_post()` creates a **Draft** with title appended `(Copy)` |
+| **Meta copy** | All `get_post_meta()` rows copied, except ephemeral keys (see below) |
+| **Taxonomy copy** | All term IDs from every registered taxonomy re-applied |
+| **Redirect** | Browser is sent to `post.php?action=edit&post={new_id}` |
+
+### 3. Elementor data
+
+Elementor stores its layout in post meta. The following keys are copied verbatim:
+
+| Meta key | Purpose |
+|---|---|
+| `_elementor_data` | Full JSON layout — all sections, columns, widgets |
+| `_elementor_edit_mode` | Must be `'builder'` for Elementor to load the editor |
+| `_elementor_template_type` | e.g. `'wp-page'` |
+| `_elementor_version` | Elementor version string |
+| `_elementor_page_settings` | Per-page Elementor settings (custom CSS, etc.) |
+
+The CSS cache key `_elementor_css` is **intentionally skipped** — Elementor regenerates it automatically on first save or preview.
+
+### 4. Keys intentionally skipped
+
+```php
+private const SKIP_META = [
+    '_edit_lock',      // editing lock (session-bound)
+    '_edit_last',      // last editor user ID
+    '_wp_old_slug',    // redirect slug history
+    '_wp_old_date',    // date-based redirect
+    '_elementor_css',  // CSS cache — regenerated automatically
+];
+```
+
+---
+
+## Security
+
+| Concern | Mitigation |
+|---|---|
+| CSRF | Nonce scoped to post ID, verified before any write |
+| Privilege escalation | `current_user_can('edit_post', $post_id)` checked twice (row action + handler) |
+| Output escaping | All HTML output uses `esc_url()`, `esc_html()`, `esc_attr()` |
+| Input sanitisation | `$_GET['post']` cast with `absint()`; nonce sanitised before verification |
+
+---
+
+## UX
+
+- The duplicate is always created as **Draft** — never published accidentally.
+- An admin notice confirms the operation on the editor screen: *"Page duplicated successfully. You are now editing the copy."*
+- Works for both **Pages** and **Posts** (and any custom post type if the `post_row_actions` filter applies).
+
+---
+
+## Adding support for custom post types
+
+To show the Duplicate action on a custom post type (e.g. `product`), add a filter in the plugin:
+
+```php
+add_filter('product_row_actions', [new BW_Duplicate_Page(), 'add_row_action'], 10, 2);
+```
+
+Or extend `BW_Duplicate_Page::__construct()` to hook additional post type filters.
+
+---
+
+## Changelog
+
+| Date | Version | Notes |
+|---|---|---|
+| 2026-04-15 | 1.0.0 | Initial implementation — Pages + Posts, full Elementor meta copy |

--- a/docs/tasks/BW-TASK-20260415-01-start.md
+++ b/docs/tasks/BW-TASK-20260415-01-start.md
@@ -1,0 +1,45 @@
+# Blackwork Governance — Task Start
+
+## 1) Context
+- Task ID: `BW-TASK-20260415-01`
+- Task title: Duplicate Page — admin row action with full Elementor layout copy
+- Request source: User request on 2026-04-15
+- Expected outcome:
+  - Add a **Duplicate** row action to the Pages (and Posts) list in wp-admin
+  - The duplicate must preserve the complete WordPress post structure (template, taxonomies, meta) **and** the full Elementor layout (`_elementor_data` and all related keys)
+  - The duplicate is created as a Draft and the editor is redirected to the new post
+  - Feature is admin-only, gated by `current_user_can('edit_post')`
+  - Implementation documented in `docs/30-features/duplicate-page/duplicate-page.md`
+
+## 2) Task Classification
+- Domain: WordPress Admin / Elementor Integration
+- Incident/Task type: Governed feature implementation
+- Risk level (L1/L2/L3): L1
+- Tier classification (0/1/2/3): 2
+- Affected systems:
+  - WordPress admin post list screen (Pages, Posts)
+  - Elementor editor (data integrity on copy)
+  - Plugin main loader (`blackwork-core-plugin.php`)
+
+## 3) Constraints
+- Admin-only load (`is_admin()` guard in main plugin file)
+- Never copy ephemeral meta: `_edit_lock`, `_edit_last`, `_wp_old_slug`, `_elementor_css`
+- Always produce a Draft, never publish on duplication
+- CSRF protection via nonce scoped to source post ID
+- No external dependencies — pure WordPress API only
+
+## 4) Deliverables
+- `includes/class-bw-duplicate-page.php` — `BW_Duplicate_Page` class
+- `docs/30-features/duplicate-page/duplicate-page.md` — feature documentation
+- `docs/tasks/BW-TASK-20260415-01-start.md` — this file
+- Registration in `blackwork-core-plugin.php`
+
+## 5) Implementation notes
+- `get_post_meta($id)` without a key returns all meta as `[ key => [value, …] ]`
+- Values must be passed through `maybe_unserialize()` before `add_post_meta()` to correctly restore arrays and objects (Elementor stores its JSON in a serialised PHP array wrapper in some versions)
+- `_elementor_css` is intentionally excluded; Elementor regenerates it automatically on first preview/save of the duplicate
+
+## 6) Status
+- [x] Implementation complete
+- [x] Documentation written
+- [ ] Closure report pending

--- a/includes/class-bw-duplicate-page.php
+++ b/includes/class-bw-duplicate-page.php
@@ -1,0 +1,252 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * BW_Duplicate_Page
+ *
+ * Adds a "Duplicate" row action to Pages (and optionally Posts) in the
+ * WordPress admin list screen. The duplicate copies:
+ *   - All standard WordPress post fields (title, content, template, …)
+ *   - All post meta — including every Elementor meta key — except
+ *     ephemeral keys that must not be transferred (_edit_lock,
+ *     _edit_last, _elementor_css).
+ *   - All taxonomy terms attached to the original.
+ *
+ * The duplicate is always created as a Draft so it is never accidentally
+ * published before the editor reviews it. After duplication the browser
+ * is redirected to the new post's edit screen.
+ */
+class BW_Duplicate_Page
+{
+    /** Meta keys that must never be copied to the duplicate. */
+    private const SKIP_META = [
+        '_edit_lock',
+        '_edit_last',
+        '_wp_old_slug',
+        '_wp_old_date',
+        '_elementor_css',   // CSS cache — Elementor regenerates on first save
+    ];
+
+    public function __construct()
+    {
+        add_filter('page_row_actions', [$this, 'add_row_action'], 10, 2);
+        add_filter('post_row_actions', [$this, 'add_row_action'], 10, 2);
+        add_action('admin_action_bw_duplicate_page', [$this, 'handle_duplicate']);
+        add_action('admin_notices', [$this, 'maybe_show_notice']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Row action
+    // -------------------------------------------------------------------------
+
+    /**
+     * Appends a "Duplicate" link to the row actions in the post/page list.
+     *
+     * @param array    $actions Existing row actions.
+     * @param \WP_Post $post    Current post object.
+     * @return array
+     */
+    public function add_row_action(array $actions, \WP_Post $post): array
+    {
+        if (!current_user_can('edit_post', $post->ID)) {
+            return $actions;
+        }
+
+        $url = $this->build_action_url($post->ID);
+        $actions['bw_duplicate'] = sprintf(
+            '<a href="%s">%s</a>',
+            esc_url($url),
+            esc_html__('Duplicate', 'bw')
+        );
+
+        return $actions;
+    }
+
+    // -------------------------------------------------------------------------
+    // Duplicate handler
+    // -------------------------------------------------------------------------
+
+    /**
+     * Processes the duplicate request, then redirects to the new post editor.
+     */
+    public function handle_duplicate(): void
+    {
+        $post_id = isset($_GET['post']) ? absint($_GET['post']) : 0;
+
+        if ($post_id <= 0) {
+            wp_die(esc_html__('Invalid post.', 'bw'));
+        }
+
+        if (
+            !isset($_GET['_wpnonce']) ||
+            !wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['_wpnonce'])), 'bw_duplicate_page_' . $post_id)
+        ) {
+            wp_die(esc_html__('Security check failed.', 'bw'));
+        }
+
+        if (!current_user_can('edit_post', $post_id)) {
+            wp_die(esc_html__('Insufficient permissions.', 'bw'));
+        }
+
+        $original = get_post($post_id);
+        if (!$original instanceof \WP_Post) {
+            wp_die(esc_html__('Post not found.', 'bw'));
+        }
+
+        $new_id = $this->duplicate_post($original);
+
+        if (is_wp_error($new_id)) {
+            wp_die(esc_html($new_id->get_error_message()));
+        }
+
+        wp_safe_redirect(
+            add_query_arg(
+                ['action' => 'edit', 'post' => $new_id, 'bw_duplicated' => 1],
+                admin_url('post.php')
+            )
+        );
+        exit;
+    }
+
+    // -------------------------------------------------------------------------
+    // Admin notice
+    // -------------------------------------------------------------------------
+
+    public function maybe_show_notice(): void
+    {
+        if (!isset($_GET['bw_duplicated'])) {
+            return;
+        }
+        echo '<div class="notice notice-success is-dismissible"><p>'
+            . esc_html__('Page duplicated successfully. You are now editing the copy.', 'bw')
+            . '</p></div>';
+    }
+
+    // -------------------------------------------------------------------------
+    // Core duplication logic
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a full copy of $original and returns the new post ID.
+     *
+     * @param  \WP_Post $original
+     * @return int|\WP_Error  New post ID on success.
+     */
+    private function duplicate_post(\WP_Post $original)
+    {
+        $new_id = wp_insert_post(
+            $this->build_post_args($original),
+            true // return WP_Error on failure
+        );
+
+        if (is_wp_error($new_id)) {
+            return $new_id;
+        }
+
+        $this->copy_meta($original->ID, $new_id);
+        $this->copy_taxonomies($original, $new_id);
+
+        return $new_id;
+    }
+
+    /**
+     * Builds the wp_insert_post() argument array for the duplicate.
+     *
+     * @param  \WP_Post $original
+     * @return array
+     */
+    private function build_post_args(\WP_Post $original): array
+    {
+        return [
+            'post_title'     => $original->post_title . ' ' . __('(Copy)', 'bw'),
+            'post_content'   => $original->post_content,
+            'post_excerpt'   => $original->post_excerpt,
+            'post_status'    => 'draft',
+            'post_type'      => $original->post_type,
+            'post_author'    => get_current_user_id(),
+            'post_parent'    => $original->post_parent,
+            'menu_order'     => $original->menu_order,
+            'comment_status' => $original->comment_status,
+            'ping_status'    => $original->ping_status,
+            'to_ping'        => $original->to_ping,
+            'post_password'  => $original->post_password,
+        ];
+    }
+
+    /**
+     * Copies all eligible post meta from the original to the duplicate.
+     * Handles both scalar and serialised values correctly.
+     *
+     * Elementor-specific keys copied:
+     *   _elementor_data           – the full JSON layout
+     *   _elementor_edit_mode      – 'builder'
+     *   _elementor_template_type  – 'wp-page', etc.
+     *   _elementor_version        – Elementor version string
+     *   _elementor_page_settings  – per-page Elementor settings
+     *
+     * Elementor-specific keys intentionally skipped:
+     *   _elementor_css            – CSS cache, regenerated automatically
+     *
+     * @param int $from_id  Source post ID.
+     * @param int $to_id    Destination post ID.
+     */
+    private function copy_meta(int $from_id, int $to_id): void
+    {
+        $all_meta = get_post_meta($from_id);
+
+        if (empty($all_meta)) {
+            return;
+        }
+
+        foreach ($all_meta as $key => $values) {
+            if (in_array($key, self::SKIP_META, true)) {
+                continue;
+            }
+
+            foreach ($values as $raw_value) {
+                // get_post_meta() always returns serialised values as strings;
+                // maybe_unserialize() restores arrays/objects before re-saving.
+                add_post_meta($to_id, $key, maybe_unserialize($raw_value));
+            }
+        }
+    }
+
+    /**
+     * Copies every taxonomy term set from the original post to the duplicate.
+     *
+     * @param \WP_Post $original
+     * @param int      $to_id
+     */
+    private function copy_taxonomies(\WP_Post $original, int $to_id): void
+    {
+        $taxonomies = get_object_taxonomies($original->post_type);
+
+        foreach ($taxonomies as $taxonomy) {
+            $term_ids = wp_get_object_terms($original->ID, $taxonomy, ['fields' => 'ids']);
+
+            if (!empty($term_ids) && !is_wp_error($term_ids)) {
+                wp_set_object_terms($to_id, $term_ids, $taxonomy);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function build_action_url(int $post_id): string
+    {
+        return add_query_arg(
+            [
+                'action'   => 'bw_duplicate_page',
+                'post'     => $post_id,
+                '_wpnonce' => wp_create_nonce('bw_duplicate_page_' . $post_id),
+            ],
+            admin_url('admin.php')
+        );
+    }
+}
+
+new BW_Duplicate_Page();


### PR DESCRIPTION
- BW_Duplicate_Page class adds a "Duplicate" row action to Pages and Posts in wp-admin
- Copies all post fields, all post meta (including every Elementor key: _elementor_data, _elementor_edit_mode, _elementor_page_settings, etc.), and all taxonomy terms from the original
- Skips ephemeral keys: _edit_lock, _edit_last, _elementor_css
- Duplicate is always created as Draft; editor is redirected to the new post on completion
- Secured via nonce + current_user_can('edit_post') double-check
- Loaded admin-only in blackwork-core-plugin.php
- Feature doc: docs/30-features/duplicate-page/duplicate-page.md
- Task: docs/tasks/BW-TASK-20260415-01-start.md