### PR TITLE
Revert cart auto-close + fix cart icon jump when badge appears

### DIFF
--- a/cart-popup/assets/js/bw-cart-popup.js
+++ b/cart-popup/assets/js/bw-cart-popup.js
@@ -838,17 +838,6 @@
 
             // Mostra stato vuoto
             this.$emptyState.fadeIn(300);
-
-            // Auto-close the panel after 1 second when the cart is empty
-            if (this.isOpen) {
-                var self = this;
-                clearTimeout(this._emptyAutoCloseTimer);
-                this._emptyAutoCloseTimer = setTimeout(function () {
-                    if (self.isOpen && (!self.cartItems || !self.cartItems.length)) {
-                        self.closePanel();
-                    }
-                }, 1000);
-            }
         },
 
         /**

--- a/includes/modules/header/assets/css/header-layout.css
+++ b/includes/modules/header/assets/css/header-layout.css
@@ -400,23 +400,6 @@ body.bw-has-sticky-header:not(.elementor-editor-active) .bw-header-spacer {
         line-height: 1 !important;
     }
 
-    @supports selector(:has(*)) {
-        .bw-custom-header__mobile-right {
-            transform: translateX(20px);
-            transition: transform 0.25s ease;
-        }
-
-        .bw-custom-header__mobile-right:has(.bw-navshop__cart-count:not(.is-empty)) {
-            transform: translateX(0);
-        }
-    }
-
-    @supports not selector(:has(*)) {
-        .bw-custom-header__mobile-right {
-            transform: translateX(0);
-            transition: transform 0.25s ease;
-        }
-    }
 
     .bw-custom-header__inner {
         padding: 14px 18px;

--- a/includes/modules/header/frontend/assets.php
+++ b/includes/modules/header/frontend/assets.php
@@ -262,7 +262,7 @@ if (!function_exists('bw_header_enqueue_assets')) {
         $css_parts[] = ".bw-custom-header__mobile-right .bw-header-search .bw-search-button{padding: {$mobile_search_padding_top}px {$mobile_search_padding_right}px {$mobile_search_padding_bottom}px {$mobile_search_padding_left}px !important;margin: 4px {$mobile_search_margin_right}px {$mobile_search_margin_bottom}px {$mobile_search_margin_left}px !important;}";
         $css_parts[] = ".bw-custom-header__mobile-right .bw-header-navshop--mobile .bw-navshop__cart{padding: {$mobile_cart_padding_top}px {$mobile_cart_padding_right}px {$mobile_cart_padding_bottom}px {$mobile_cart_padding_left}px !important;margin: {$mobile_cart_margin_top}px {$mobile_cart_margin_right}px {$mobile_cart_margin_bottom}px {$mobile_cart_margin_left}px !important;}";
         $css_parts[] = ".bw-custom-header__mobile-right .bw-header-navshop--mobile .bw-navshop__cart-count:not(.is-empty){top:26% !important;right:17px !important;transform: translate({$mobile_cart_badge_offset_x}px, calc(-50% + {$mobile_cart_badge_offset_y}px)) !important;display:inline-flex !important;align-items:center !important;justify-content:center !important;min-width:14px !important;height:14px !important;padding:0 3px !important;line-height:1 !important;font-size:8px !important;font-weight:400 !important;font-family:inherit !important;font-variant-numeric:tabular-nums !important;}";
-        $css_parts[] = ".bw-custom-header__mobile-right .bw-header-navshop--mobile .bw-navshop__cart:has(.bw-navshop__cart-count.is-empty){margin-right: 8px !important;}";
+        // (badge is position:absolute — no flow-space compensation needed)
         $css_parts[] = "}";
 
         // — Desktop breakpoint rules —


### PR DESCRIPTION
- Revert the 1s auto-close on empty cart (user preference)
- Remove the @supports(:has) translateX(20px→0) shift on .bw-custom-header__mobile-right — the badge is position:absolute so it never affected flow width; the 20px shift was causing the cart icon to jump left when a product was added
- Remove the related margin-right:8px compensation rule