### PR TITLE
Fix reviews modal mobile responsiveness: sticky footer, remove steps …

### DIFF
--- a/assets/css/bw-reviews.css
+++ b/assets/css/bw-reviews.css
@@ -863,12 +863,12 @@
     position: relative !important;
     width: min(100%, 1040px) !important;
     max-height: calc(100vh - 64px) !important;
-    overflow: auto !important;
+    overflow-x: hidden !important;
+    overflow-y: auto !important;
     border-radius: 28px !important;
     background: var(--bw-reviews-modal-bg) !important;
     border: 1px solid var(--bw-reviews-modal-border) !important;
     box-shadow: var(--bw-reviews-modal-shadow) !important;
-    overflow: hidden !important;
 }
 
 .bw-reviews-modal__dialog-scroll::before {
@@ -1516,7 +1516,11 @@ body.bw-reviews-modal-open {
 
     .bw-reviews-modal__inner {
         gap: 20px !important;
-        padding: 72px 18px 22px !important;
+        padding: 72px 18px 0 !important;
+    }
+
+    .bw-reviews-modal__steps {
+        min-height: 0 !important;
     }
 
     .bw-reviews-modal__close {
@@ -1552,8 +1556,14 @@ body.bw-reviews-modal-open {
     }
 
     .bw-reviews-modal__footer {
+        position: sticky !important;
+        bottom: 0 !important;
+        z-index: 1 !important;
         grid-template-columns: 1fr !important;
         gap: 16px !important;
+        background: var(--bw-reviews-modal-bg) !important;
+        padding-top: 12px !important;
+        padding-bottom: max(22px, env(safe-area-inset-bottom)) !important;
     }
 
     .bw-reviews-modal__back,


### PR DESCRIPTION
…min-height

- Remove 360px min-height from __steps on mobile so it no longer forces the modal content taller than the 92vh cap
- Make __footer position:sticky so the Continue/Submit button stays pinned at the bottom of the scroll area even when step content is tall
- Add modal-bg background and safe-area-inset-bottom padding to the sticky footer so it looks correct on iOS Safari with bottom navigation bar
- Remove bottom padding from __inner (footer now owns its own bottom spacing)

https://claude.ai/code/session_011AEyNEyucsA22c58HevSTk