### PR TITLE
Switch reviews grid to CSS multi-column layout for masonry packing

### DIFF
--- a/assets/css/bw-reviews.css
+++ b/assets/css/bw-reviews.css
@@ -501,20 +501,25 @@
 
 .elementor-widget-bw-reviews .bw-reviews-grid,
 .bw-reviews-grid {
-    display: grid !important;
-    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
-    gap: 22px !important;
-    align-items: start !important;
+    columns: 2 !important;
+    column-gap: 22px !important;
 }
 
 .elementor-widget-bw-reviews .bw-reviews-card,
 .bw-reviews-card {
     display: grid !important;
     gap: 14px !important;
+    break-inside: avoid !important;
     min-height: 0 !important;
     padding: 20px !important;
+    margin-bottom: 22px !important;
     border-radius: 8px !important;
     background: var(--bw-reviews-surface) !important;
+}
+
+.elementor-widget-bw-reviews .bw-reviews-card:last-child,
+.bw-reviews-card:last-child {
+    margin-bottom: 0 !important;
 }
 
 .elementor-widget-bw-reviews .bw-reviews-card.is-reveal-pending,
@@ -1387,11 +1392,6 @@ body.bw-reviews-modal-open {
         justify-content: space-between !important;
     }
 
-    .elementor-widget-bw-reviews .bw-reviews-grid,
-    .bw-reviews-grid {
-        grid-template-columns: 1fr 1fr !important;
-    }
-
     .bw-reviews-modal__dialog {
         padding: 24px !important;
     }
@@ -1483,14 +1483,15 @@ body.bw-reviews-modal-open {
 
     .elementor-widget-bw-reviews .bw-reviews-grid,
     .bw-reviews-grid {
-        grid-template-columns: 1fr !important;
-        gap: 16px !important;
+        columns: 1 !important;
+        column-gap: 0 !important;
     }
 
     .elementor-widget-bw-reviews .bw-reviews-card,
     .bw-reviews-card {
         min-height: 0 !important;
         padding: 22px !important;
+        margin-bottom: 16px !important;
     }
 
     .elementor-widget-bw-reviews .bw-reviews-card__header,


### PR DESCRIPTION
CSS Grid rows always take the height of the tallest card in the row, leaving gaps below shorter cards. Switching to CSS columns (multi-column layout) makes cards pack tightly like masonry: each card sits directly below the previous one in its column with no wasted vertical space.

- Replace display:grid + grid-template-columns with columns:2 + column-gap
- Add break-inside:avoid and margin-bottom to cards so they never split across columns and keep consistent spacing
- Add :last-child rule to remove trailing bottom margin
- Remove now-redundant grid-template-columns overrides from breakpoints
- Mobile (≤767px): columns:1 for single-column stack

https://claude.ai/code/session_011AEyNEyucsA22c58HevSTk