### PR TITLE
Fix mobile header: search icon touch area and tap flash on all icons

### DIFF
--- a/includes/modules/header/assets/css/header-layout.css
+++ b/includes/modules/header/assets/css/header-layout.css
@@ -383,6 +383,13 @@ body.bw-has-sticky-header:not(.elementor-editor-active) .bw-header-spacer {
         margin-top: 3px;
     }
 
+    .bw-custom-header .bw-search-button,
+    .bw-custom-header .bw-navigation__toggle,
+    .bw-custom-header .bw-navshop__cart {
+        -webkit-tap-highlight-color: transparent;
+        touch-action: manipulation;
+    }
+
     .bw-custom-header .bw-navshop__cart-count {
         font-size: 11px;
         font-weight: 400;

--- a/includes/modules/header/frontend/assets.php
+++ b/includes/modules/header/frontend/assets.php
@@ -254,7 +254,7 @@ if (!function_exists('bw_header_enqueue_assets')) {
         $css_parts[] = ".bw-custom-header .bw-navshop--hide-account-mobile .bw-navshop__account{display:none;}";
         $css_parts[] = ".bw-custom-header .bw-navshop__cart-label{display:none;}";
         $css_parts[] = ".bw-custom-header .bw-navshop__cart-icon{display:inline-flex;}";
-        $css_parts[] = ".bw-custom-header .bw-search-button{display:inline-flex !important;background:transparent !important;border:none !important;box-shadow:none !important;padding:0 !important;min-width:auto !important;min-height:auto !important;}";
+        $css_parts[] = ".bw-custom-header .bw-search-button{display:inline-flex !important;background:transparent !important;border:none !important;box-shadow:none !important;padding:0 !important;}";
         $css_parts[] = ".bw-custom-header .bw-search-button__label{display:none;}";
         $css_parts[] = ".bw-custom-header .bw-search-button__icon{display:inline-flex;background:transparent !important;border:none !important;border-radius:0 !important;padding:0 !important;}";
         $css_parts[] = ".bw-custom-header__mobile-right{gap: {$mobile_right_icons_gap}px !important;}";


### PR DESCRIPTION
Touch area bug: inline CSS in assets.php was outputting min-width:auto;min-height:auto on .bw-search-button inside the mobile breakpoint, overriding the 30px minimum from header-layout.css. Cart and hamburger kept their 30px tap targets; search collapsed to the bare 16px icon. Removing the auto overrides restores parity.

Tap flash bug: none of the three mobile header icons set -webkit-tap-highlight-color, so WebKit browsers showed a gray/blue rectangle flash on every tap. Added -webkit-tap-highlight-color:transparent and touch-action:manipulation to search button, hamburger toggle, and cart link inside the ≤1024px breakpoint.

https://claude.ai/code/session_011AEyNEyucsA22c58HevSTk