### PR TITLE
Stabilize responsive filter drawer: animated accordion, surgical DOM …

### DIFF
--- a/assets/css/bw-product-grid.css
+++ b/assets/css/bw-product-grid.css
@@ -413,8 +413,8 @@
   flex-direction: column;
   align-items: stretch;
   gap: 0;
-  padding: 5px 16px 12px;
-  border-bottom: none;
+  padding: 6px 16px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-mobile-filter-drawer-title-row {
@@ -470,10 +470,10 @@
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-mobile-filter-sheet-handle-bar {
   display: block;
-  width: 90px;
+  width: 40px;
   height: 4px;
   border-radius: 999px;
-  background: rgba(113, 113, 122, 0.85);
+  background: rgba(255, 255, 255, 0.22);
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-mobile-filter-panel__body--drawer {
@@ -1661,8 +1661,12 @@ body.bw-fpw-drawer-no-scroll {
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-drawer-groups {
   display: grid;
-  gap: 4px;
+  gap: 0;
   padding-bottom: 2px;
+}
+
+.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group + .bw-fpw-discovery-group {
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group {
@@ -1681,9 +1685,9 @@ body.bw-fpw-drawer-no-scroll {
   gap: 12px;
   width: 100%;
   min-height: 44px;
-  padding: 0.35rem 12px;
+  padding: 10px 12px;
   border: none;
-  border-radius: 999px;
+  border-radius: 10px;
   background: transparent;
   color: inherit;
   font-size: 14px;
@@ -1705,7 +1709,7 @@ body.bw-fpw-drawer-no-scroll {
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__toggle:hover .bw-fpw-discovery-group__title,
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__toggle:focus-visible .bw-fpw-discovery-group__title {
-  color: rgba(247, 246, 242, 0.56);
+  color: rgba(247, 246, 242, 0.95);
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__chevron {
@@ -1713,9 +1717,9 @@ body.bw-fpw-drawer-no-scroll {
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
-  width: 16px;
-  height: 16px;
-  color: rgba(247, 246, 242, 0.48);
+  width: 20px;
+  height: 20px;
+  color: rgba(247, 246, 242, 0.5);
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__chevron-icon {
@@ -1723,11 +1727,19 @@ body.bw-fpw-drawer-no-scroll {
   height: 16px;
   display: block;
   transform: rotate(0deg);
-  transition: transform 0.22s ease;
+  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group.is-open .bw-fpw-discovery-group__chevron-icon {
   transform: rotate(180deg);
+}
+
+.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group.is-open .bw-fpw-discovery-group__title {
+  color: rgba(247, 246, 242, 0.95);
+}
+
+.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group.is-open .bw-fpw-discovery-group__chevron {
+  color: rgba(247, 246, 242, 0.72);
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__panel {
@@ -1746,11 +1758,12 @@ body.bw-fpw-drawer-no-scroll {
   position: relative;
   display: flex;
   align-items: center;
-  min-height: 44px;
-  margin: 8px 2px 6px 2px;
+  min-height: 40px;
+  margin: 2px 0 8px;
   padding: 0 10px 0 36px;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
   color: rgba(247, 246, 242, 0.7);
 }
 
@@ -1804,7 +1817,7 @@ body.bw-fpw-drawer-no-scroll {
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-options {
   display: grid;
-  gap: 3px;
+  gap: 2px;
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__panel .bw-fpw-discovery-options {
@@ -1812,7 +1825,7 @@ body.bw-fpw-drawer-no-scroll {
   overflow-y: auto;
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
-  padding: 8px;
+  padding: 4px 2px;
   scrollbar-width: thin;
   scrollbar-color: rgba(255, 255, 255, 0.22) rgba(255, 255, 255, 0.06);
 }
@@ -2140,10 +2153,10 @@ body.bw-fpw-drawer-no-scroll {
   justify-content: center;
   min-height: 52px;
   padding: 12px 16px;
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 999px;
   background: transparent;
-  color: rgba(247, 246, 242, 0.75);
+  color: rgba(247, 246, 242, 0.7);
   font-size: 14px;
   font-weight: 500;
   line-height: 1.2;
@@ -2185,7 +2198,7 @@ body.bw-fpw-drawer-no-scroll {
   line-height: 1.2;
   text-align: center;
   letter-spacing: 0;
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.24);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.16);
   transition: opacity 180ms ease-out, background-color 180ms ease-out, transform 180ms ease-out;
 }
 

--- a/assets/css/bw-product-grid.css
+++ b/assets/css/bw-product-grid.css
@@ -410,11 +410,53 @@
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-mobile-filter-panel__header--drawer {
   display: flex;
-  align-items: center;
-  justify-content: center;
+  flex-direction: column;
+  align-items: stretch;
   gap: 0;
   padding: 5px 16px 12px;
   border-bottom: none;
+}
+
+.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-mobile-filter-drawer-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 36px;
+}
+
+.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-mobile-filter-drawer-title {
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.3;
+  color: rgba(247, 246, 242, 0.9);
+}
+
+.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-drawer-close-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: rgba(247, 246, 242, 0.6);
+  cursor: pointer;
+  border-radius: 50%;
+  transition: background 150ms ease-out, color 150ms ease-out;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-drawer-close-btn:hover,
+.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-drawer-close-btn:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(247, 246, 242, 0.9);
+}
+
+.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-drawer-close-btn svg {
+  display: block;
+  flex-shrink: 0;
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-mobile-filter-sheet-handle {
@@ -1689,12 +1731,15 @@ body.bw-fpw-drawer-no-scroll {
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__panel {
-  display: none;
-  padding: 0 6px 6px 6px;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 220ms ease-in-out;
+  padding: 0 6px;
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group.is-open .bw-fpw-discovery-group__panel {
-  display: block;
+  max-height: 520px;
+  padding: 0 6px 6px;
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group-search {
@@ -1768,7 +1813,6 @@ body.bw-fpw-drawer-no-scroll {
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
   padding: 8px;
-  scrollbar-gutter: stable;
   scrollbar-width: thin;
   scrollbar-color: rgba(255, 255, 255, 0.22) rgba(255, 255, 255, 0.06);
 }
@@ -2082,8 +2126,45 @@ body.bw-fpw-drawer-no-scroll {
   left: auto;
   right: auto;
   bottom: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
   padding: 12px 16px max(2rem, calc(env(safe-area-inset-bottom, 0px) + 0.5rem));
   border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-drawer-clear-all {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 52px;
+  padding: 12px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  background: transparent;
+  color: rgba(247, 246, 242, 0.75);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.2;
+  white-space: nowrap;
+  cursor: pointer;
+  box-sizing: border-box;
+  transition: background 150ms ease-out, color 150ms ease-out;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+}
+
+.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-drawer-clear-all:hover,
+.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-drawer-clear-all:focus-visible {
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(247, 246, 242, 0.95);
+}
+
+.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-mobile-filter-panel__footer--drawer .bw-fpw-mobile-apply--drawer {
+  flex: 1 1 auto;
+  width: auto;
+  max-width: none;
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-mobile-apply--drawer {

--- a/assets/js/bw-product-grid.js
+++ b/assets/js/bw-product-grid.js
@@ -1971,10 +1971,14 @@
             renderedIndex += 1;
         }
 
-        html += '<label class="bw-fpw-discovery-group-search">';
-        html += '<span class="bw-fpw-discovery-group-search__icon" aria-hidden="true"></span>';
-        html += '<input class="bw-fpw-discovery-group-search__input" type="search" data-widget-id="' + widgetId + '" data-group="' + groupKey + '" data-surface="' + escapeHtml(surfaceKey || 'drawer') + '" value="' + escapeHtml(state.ui.optionSearches[groupKey]) + '" placeholder="' + escapeHtml(groupConfig.placeholder) + '" autocomplete="off" />';
-        html += '</label>';
+        var showSearchInput = (surfaceKey || 'drawer') !== 'drawer' || options.length > 5;
+
+        if (showSearchInput) {
+            html += '<label class="bw-fpw-discovery-group-search">';
+            html += '<span class="bw-fpw-discovery-group-search__icon" aria-hidden="true"></span>';
+            html += '<input class="bw-fpw-discovery-group-search__input" type="search" data-widget-id="' + widgetId + '" data-group="' + groupKey + '" data-surface="' + escapeHtml(surfaceKey || 'drawer') + '" value="' + escapeHtml(state.ui.optionSearches[groupKey]) + '" placeholder="' + escapeHtml(groupConfig.placeholder) + '" autocomplete="off" />';
+            html += '</label>';
+        }
         html += '<div class="bw-fpw-discovery-options">';
 
         if (orderedVisibleOptions.length) {
@@ -2051,7 +2055,7 @@
 
         if (groupKey === 'years') {
             html += '<section class="bw-fpw-discovery-group bw-fpw-discovery-group--years' + (isOpen ? ' is-open' : '') + '" data-widget-id="' + widgetId + '" data-group="years">';
-            html += '<button class="bw-fpw-discovery-group__toggle" type="button" data-widget-id="' + widgetId + '" data-group="years">';
+            html += '<button class="bw-fpw-discovery-group__toggle" type="button" aria-expanded="' + (isOpen ? 'true' : 'false') + '" data-widget-id="' + widgetId + '" data-group="years">';
             html += '<span class="bw-fpw-discovery-group__title">' + escapeHtml(groupConfig.label) + '</span>';
             html += '<span class="bw-fpw-discovery-group__chevron" aria-hidden="true">' + chevronIcon + '</span>';
             html += '</button>';
@@ -2064,7 +2068,7 @@
         }
 
         html += '<section class="bw-fpw-discovery-group' + (isOpen ? ' is-open' : '') + '" data-widget-id="' + widgetId + '" data-group="' + groupKey + '">';
-        html += '<button class="bw-fpw-discovery-group__toggle" type="button" data-widget-id="' + widgetId + '" data-group="' + groupKey + '">';
+        html += '<button class="bw-fpw-discovery-group__toggle" type="button" aria-expanded="' + (isOpen ? 'true' : 'false') + '" data-widget-id="' + widgetId + '" data-group="' + groupKey + '">';
         html += '<span class="bw-fpw-discovery-group__title">' + escapeHtml(groupConfig.label) + '</span>';
         html += '<span class="bw-fpw-discovery-group__chevron" aria-hidden="true">' + chevronIcon + '</span>';
         html += '</button>';
@@ -2123,14 +2127,26 @@
 
             if ((targetGroupKey && targetGroupKey !== groupKey && $existing.length) ? false : previousMarkup !== markup || !$existing.length) {
                 if ($existing.length) {
-                    $existing.replaceWith(markup);
+                    // Surgical update — preserve the existing section element to keep CSS transitions alive.
+                    var $tmpWrapper = $('<div>').html(markup);
+                    var $tmpSection = $tmpWrapper.children('.bw-fpw-discovery-group').first();
+                    var newIsOpen = $tmpSection.hasClass('is-open');
+                    var $tmpPanel = $tmpSection.children('.bw-fpw-discovery-group__panel').first();
+
+                    $existing.toggleClass('is-open', newIsOpen);
+                    var $existingPanel = $existing.children('.bw-fpw-discovery-group__panel').first();
+                    $existingPanel.attr('aria-hidden', newIsOpen ? 'false' : 'true');
+                    $existingPanel.html($tmpPanel.html());
+                    $existing.children('.bw-fpw-discovery-group__toggle').first().attr('aria-expanded', newIsOpen ? 'true' : 'false');
+
+                    $current = $existing;
                 } else if (nextSelector && $groups.children(nextSelector).length) {
                     $(markup).insertBefore($groups.children(nextSelector).first());
+                    $current = $groups.children('.bw-fpw-discovery-group[data-widget-id="' + widgetId + '"][data-group="' + groupKey + '"]');
                 } else {
                     $groups.append(markup);
+                    $current = $groups.children('.bw-fpw-discovery-group[data-widget-id="' + widgetId + '"][data-group="' + groupKey + '"]');
                 }
-
-                $current = $groups.children('.bw-fpw-discovery-group[data-widget-id="' + widgetId + '"][data-group="' + groupKey + '"]');
             }
 
             if ($current.length && nextSelector) {
@@ -2155,6 +2171,29 @@
         preserveDiscoveryDrawerScrollPosition(widgetId, function () {
             patchDiscoveryDrawerGroups(widgetId, groupKey);
         });
+    }
+
+    function applyDiscoveryGroupOpenState(widgetId, groupKey) {
+        var state = getDiscoveryState(widgetId);
+
+        if (!state) {
+            return;
+        }
+
+        var isOpen = groupKey === 'years'
+            ? (!!state.ui.openGroups.years || hasActiveYearFilter(state))
+            : (!!state.ui.openGroups[groupKey] || !!normalizeDiscoveryText(state.ui.optionSearches[groupKey]));
+
+        var $groups = $('.bw-fpw-drawer-groups[data-widget-id="' + widgetId + '"]');
+        var $section = $groups.children('.bw-fpw-discovery-group[data-group="' + groupKey + '"]');
+
+        if (!$section.length) {
+            return;
+        }
+
+        $section.toggleClass('is-open', isOpen);
+        $section.children('.bw-fpw-discovery-group__panel').attr('aria-hidden', isOpen ? 'false' : 'true');
+        $section.children('.bw-fpw-discovery-group__toggle').attr('aria-expanded', isOpen ? 'true' : 'false');
     }
 
     function getDiscoveryVisibleFilterSummary(state, groupKey) {
@@ -4418,7 +4457,7 @@
             }
 
             state.ui.openGroups[groupKey] = !state.ui.openGroups[groupKey];
-            renderDiscoveryDrawerGroup(widgetId, groupKey);
+            applyDiscoveryGroupOpenState(widgetId, groupKey);
         });
 
         $(document).on('input', '.bw-fpw-discovery-group-search__input', function () {
@@ -4698,6 +4737,36 @@
             var widgetId = $(this).closest('.bw-fpw-mobile-filter-panel').attr('data-widget-id') || $(this).closest('.bw-fpw-mobile-filter').attr('data-widget-id');
             filterPosts(widgetId);
             closeMobilePanel(widgetId);
+        });
+
+        $(document).on('click', '.bw-fpw-drawer-clear-all', function (e) {
+            e.preventDefault();
+
+            var widgetId = $(this).attr('data-widget-id')
+                || $(this).closest('.bw-fpw-mobile-filter-panel').attr('data-widget-id')
+                || $(this).closest('.bw-fpw-mobile-filter').attr('data-widget-id');
+            var state = getDiscoveryState(widgetId);
+
+            if (!state) {
+                return;
+            }
+
+            state.subcategories = [];
+            state.tags = [];
+            state.year = createEmptyYearState();
+            state.ui.yearDraft = createEmptyYearState();
+
+            getDiscoveryGroupConfigs().forEach(function (groupConfig) {
+                var groupKey = groupConfig.key;
+
+                if (groupKey !== 'types' && groupKey !== 'tags' && groupKey !== 'years' && isDiscoveryTokenGroup(groupKey)) {
+                    setDiscoverySelectionState(state, groupKey, []);
+                }
+            });
+
+            clearDiscoveryVisibleFilterFeedback(widgetId, false);
+            renderDiscoveryUi(widgetId);
+            filterPosts(widgetId);
         });
 
         $(document).on('click', '.bw-fpw-mobile-filter-panel--drawer', function (e) {

--- a/includes/widgets/class-bw-product-grid-widget.php
+++ b/includes/widgets/class-bw-product-grid-widget.php
@@ -1202,6 +1202,12 @@ class BW_Product_Grid_Widget extends Widget_Base {
                                 <div class="bw-fpw-mobile-filter-sheet-handle" aria-hidden="true">
                                     <span class="bw-fpw-mobile-filter-sheet-handle-bar"></span>
                                 </div>
+                                <div class="bw-fpw-mobile-filter-drawer-title-row">
+                                    <span class="bw-fpw-mobile-filter-drawer-title"><?php echo esc_html( $drawer_title ); ?></span>
+                                    <button class="bw-fpw-mobile-filter-close bw-fpw-drawer-close-btn" type="button" aria-label="<?php esc_attr_e( 'Close filters', 'bw-elementor-widgets' ); ?>">
+                                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+                                    </button>
+                                </div>
                             </div>
 
                             <div class="bw-fpw-mobile-filter-panel__body bw-fpw-mobile-filter-panel__body--drawer">
@@ -1212,6 +1218,7 @@ class BW_Product_Grid_Widget extends Widget_Base {
                             </div>
 
                             <div class="bw-fpw-mobile-filter-panel__footer bw-fpw-mobile-filter-panel__footer--drawer">
+                                <button class="bw-fpw-drawer-clear-all" type="button" data-widget-id="<?php echo esc_attr( $widget_id ); ?>"><?php esc_html_e( 'Clear all', 'bw-elementor-widgets' ); ?></button>
                                 <button class="<?php echo esc_attr( implode( ' ', $apply_button_classes ) ); ?>" type="button"><?php echo esc_html( $mobile_show_results ); ?></button>
                             </div>
                         </div>


### PR DESCRIPTION
…patching, title/close/clear-all, conditional search

- Replace display:none/block on accordion panel with max-height transition (220ms) so open/close animates smoothly
- Add applyDiscoveryGroupOpenState() that toggles is-open/aria-hidden/aria-expanded directly on existing DOM elements, bypassing replaceWith entirely for pure open/close operations
- Update toggle click handler to call applyDiscoveryGroupOpenState instead of renderDiscoveryDrawerGroup
- Surgical content patch in patchDiscoveryDrawerGroups: when section already exists update innerHTML/classes in place rather than destroying and recreating the element (preserves CSS transitions)
- Add aria-expanded to accordion toggle buttons
- Drawer header: add title ("Filters") and X close button (reuses existing bw-fpw-mobile-filter-close handler)
- Drawer footer: add "Clear all" button beside "Show results"; JS handler clears all filter state and re-renders
- Skip per-group search input in drawer surface when group has ≤5 options
- Remove scrollbar-gutter: stable from options list (was reserving permanent gutter width)

https://claude.ai/code/session_011AEyNEyucsA22c58HevSTk