### PR TITLE
Fix sticky hover on touch and restore single-open accordion

### DIFF
--- a/assets/css/bw-product-grid.css
+++ b/assets/css/bw-product-grid.css
@@ -1701,15 +1701,24 @@ body.bw-fpw-drawer-no-scroll {
   transition: color 180ms ease-out;
 }
 
-.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__toggle:hover,
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__toggle:focus-visible {
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.08);
   outline: none;
 }
 
-.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__toggle:hover .bw-fpw-discovery-group__title,
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__toggle:focus-visible .bw-fpw-discovery-group__title {
   color: rgba(247, 246, 242, 0.95);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__toggle:hover {
+    background: rgba(255, 255, 255, 0.08);
+    outline: none;
+  }
+
+  .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__toggle:hover .bw-fpw-discovery-group__title {
+    color: rgba(247, 246, 242, 0.95);
+  }
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__chevron {

--- a/assets/js/bw-product-grid.js
+++ b/assets/js/bw-product-grid.js
@@ -4456,7 +4456,18 @@
                 return;
             }
 
-            state.ui.openGroups[groupKey] = !state.ui.openGroups[groupKey];
+            var willOpen = !state.ui.openGroups[groupKey];
+
+            if (willOpen) {
+                Object.keys(state.ui.openGroups).forEach(function (key) {
+                    if (key !== groupKey && state.ui.openGroups[key]) {
+                        state.ui.openGroups[key] = false;
+                        applyDiscoveryGroupOpenState(widgetId, key);
+                    }
+                });
+            }
+
+            state.ui.openGroups[groupKey] = willOpen;
             applyDiscoveryGroupOpenState(widgetId, groupKey);
         });
 


### PR DESCRIPTION
CSS: guard toggle :hover background inside @media (hover: hover) and (pointer: fine) — prevents the highlight getting stuck on touch devices after tap. :focus-visible kept unconditionally for keyboard nav.

JS: toggle handler now closes all other open groups before opening the tapped one. Closing calls applyDiscoveryGroupOpenState on each affected key so the max-height animation plays for all of them simultaneously.

https://claude.ai/code/session_011AEyNEyucsA22c58HevSTk