### PR TITLE
Fix search field bleeding through closed accordion panel

### DIFF
--- a/assets/css/bw-product-grid.css
+++ b/assets/css/bw-product-grid.css
@@ -1754,6 +1754,7 @@ body.bw-fpw-drawer-no-scroll {
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__panel {
   max-height: 0;
   overflow: hidden;
+  clip-path: inset(0);
   transition: max-height 220ms ease-in-out;
   padding: 0 6px;
 }
@@ -1768,11 +1769,10 @@ body.bw-fpw-drawer-no-scroll {
   display: flex;
   align-items: center;
   min-height: 40px;
-  margin: 2px 0 8px;
+  margin: 0 0 8px;
   padding: 0 10px 0 36px;
   border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.04);
+  background: rgba(255, 255, 255, 0.06);
   color: rgba(247, 246, 242, 0.7);
 }
 


### PR DESCRIPTION
Two fixes:
1. Add clip-path: inset(0) on the panel — forces a hard GPU-composited clip at the element boundary, more aggressive than overflow:hidden alone and eliminates the 1-2px sub-pixel bleed of child borders/backgrounds through the max-height:0 clip.
2. Remove border from group-search input (added in polish pass) and reset margin-top to 0 — the 1px solid border was the high-contrast element bleeding through; removing it makes any residual bleed imperceptible. Slight background bump to 0.06 to compensate for lost definition.

https://claude.ai/code/session_011AEyNEyucsA22c58HevSTk