### PR TITLE
Pixel correction pass: remove separators, fix search field, align opt…

### DIFF
--- a/assets/css/bw-product-grid.css
+++ b/assets/css/bw-product-grid.css
@@ -1661,12 +1661,8 @@ body.bw-fpw-drawer-no-scroll {
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-drawer-groups {
   display: grid;
-  gap: 0;
+  gap: 4px;
   padding-bottom: 2px;
-}
-
-.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group + .bw-fpw-discovery-group {
-  border-top: 1px solid rgba(255, 255, 255, 0.05);
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group {
@@ -1756,29 +1752,30 @@ body.bw-fpw-drawer-no-scroll {
   overflow: hidden;
   clip-path: inset(0);
   transition: max-height 220ms ease-in-out;
-  padding: 0 6px;
+  padding: 0;
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group.is-open .bw-fpw-discovery-group__panel {
   max-height: 520px;
-  padding: 0 6px 6px;
+  padding: 0 0 8px;
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group-search {
   position: relative;
   display: flex;
   align-items: center;
-  min-height: 40px;
-  margin: 0 0 8px;
-  padding: 0 10px 0 36px;
-  border-radius: 10px;
-  background: rgba(255, 255, 255, 0.06);
-  color: rgba(247, 246, 242, 0.7);
+  min-height: 44px;
+  margin: 0;
+  padding: 0 12px 0 44px;
+  border-radius: 0;
+  background: transparent;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+  color: rgba(247, 246, 242, 0.55);
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group-search__icon {
   position: absolute;
-  left: 12px;
+  left: 14px;
   width: 14px;
   height: 14px;
   border: 2px solid currentColor;
@@ -1865,8 +1862,8 @@ body.bw-fpw-drawer-no-scroll {
   align-items: center;
   gap: 8px;
   width: 100%;
-  min-height: 36px;
-  padding: 6px 16px 6px 10px;
+  min-height: 44px;
+  padding: 8px 16px 8px 12px;
   position: relative;
   border: 0;
   border-radius: 12px;


### PR DESCRIPTION
…ions

Dividers: remove border-top sibling selector that caused visible lines between closed rows. Restore gap: 4px between groups for compact breathing room without lines.

Panel: remove 6px horizontal padding from both closed and open states so search field and options span full width aligned with the toggle row.

Search field: transparent background (was rgba(0.06) pill), border-radius: 0 (was 10px), no margin, height 44px to match toggle. Adds border-bottom: 1px rgba(0.07) as the only visual separator before options. Icon repositioned from left:12px to left:14px to align with the wider padding. Color dimmed to rgba(0.55) so it reads clearly as placeholder, not active input.

Option rows: min-height 36→44px, padding 6px→8px vertical and 10→12px left to match spacing in reference image.

https://claude.ai/code/session_011AEyNEyucsA22c58HevSTk