### PR TITLE
Fix double X close button and Years panel bleed

### DIFF
--- a/assets/css/bw-product-grid.css
+++ b/assets/css/bw-product-grid.css
@@ -432,6 +432,10 @@
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-drawer-close-btn {
+  position: static;
+  top: auto;
+  right: auto;
+  transform: none;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -446,6 +450,11 @@
   transition: background 150ms ease-out, color 150ms ease-out;
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
+}
+
+.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-drawer-close-btn::before {
+  content: none;
+  display: none;
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-drawer-close-btn:hover,
@@ -1751,13 +1760,16 @@ body.bw-fpw-drawer-no-scroll {
   max-height: 0;
   overflow: hidden;
   clip-path: inset(0);
-  transition: max-height 220ms ease-in-out;
+  visibility: hidden;
+  transition: max-height 220ms ease-in-out, visibility 0s 220ms;
   padding: 0;
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group.is-open .bw-fpw-discovery-group__panel {
   max-height: 520px;
   padding: 0 0 8px;
+  visibility: visible;
+  transition: max-height 220ms ease-in-out, visibility 0s;
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group-search {


### PR DESCRIPTION
Close button: .bw-fpw-mobile-filter-close has position:absolute + a ::before pseudo-element that adds an SVG X icon. The drawer close button inherited both, causing the ::before icon to render alongside the inline SVG in the PHP button. Fix: add position:static + top/right/transform reset to return the button to normal flex flow; suppress ::before with content:none on the scoped .bw-fpw-drawer-close-btn rule.

Years bleed: clip-path:inset(0) alone is not reliable on all WebKit builds for sub-pixel border-radius backgrounds. Added visibility:hidden to the closed panel state with a 220ms delay transition (hides AFTER the close animation completes). Open state sets visibility:visible with 0s delay (shows BEFORE the open animation starts). This is the reliable fix regardless of rendering engine.

https://claude.ai/code/session_011AEyNEyucsA22c58HevSTk