### PR TITLE
Increase year inputs gap and close button size

### DIFF
--- a/assets/css/bw-product-grid.css
+++ b/assets/css/bw-product-grid.css
@@ -439,8 +439,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: 44px;
+  height: 44px;
   padding: 0;
   border: none;
   background: transparent;
@@ -2061,7 +2061,7 @@ body.bw-fpw-drawer-no-scroll {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   align-items: start;
-  gap: 10px;
+  gap: 16px;
   margin: 0 4px 12px 4px;
 }
 

--- a/includes/widgets/class-bw-product-grid-widget.php
+++ b/includes/widgets/class-bw-product-grid-widget.php
@@ -1205,7 +1205,7 @@ class BW_Product_Grid_Widget extends Widget_Base {
                                 <div class="bw-fpw-mobile-filter-drawer-title-row">
                                     <span class="bw-fpw-mobile-filter-drawer-title"><?php echo esc_html( $drawer_title ); ?></span>
                                     <button class="bw-fpw-mobile-filter-close bw-fpw-drawer-close-btn" type="button" aria-label="<?php esc_attr_e( 'Close filters', 'bw-elementor-widgets' ); ?>">
-                                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+                                        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
                                     </button>
                                 </div>
                             </div>


### PR DESCRIPTION
Year inputs: gap 10px → 16px between FROM and TO columns — more breathing room between the two selects.

Close button: 32×32 → 44×44px for a proper touch target; SVG icon 20→22px to fill the larger button proportionally.

https://claude.ai/code/session_011AEyNEyucsA22c58HevSTk