### PR TITLE
Fix accordion close glitch: remove clip-path from panel

### DIFF
--- a/assets/css/bw-product-grid.css
+++ b/assets/css/bw-product-grid.css
@@ -1759,7 +1759,6 @@ body.bw-fpw-drawer-no-scroll {
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__panel {
   max-height: 0;
   overflow: hidden;
-  clip-path: inset(0);
   visibility: hidden;
   transition: max-height 220ms ease-in-out, visibility 0s 220ms;
   padding: 0;


### PR DESCRIPTION
clip-path: inset(0) forced a GPU compositing layer that caused a lateral shift/shrink artifact during the max-height close transition. visibility:hidden with delayed transition is sufficient to prevent bleed-through.