### PR TITLE
Rewrite accordion with JS-driven measured height animation

### DIFF
--- a/assets/css/bw-product-grid.css
+++ b/assets/css/bw-product-grid.css
@@ -1741,7 +1741,7 @@ body.bw-fpw-drawer-no-scroll {
   height: 16px;
   display: block;
   transform: rotate(0deg);
-  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: transform 320ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group.is-open .bw-fpw-discovery-group__chevron-icon {
@@ -1757,18 +1757,16 @@ body.bw-fpw-drawer-no-scroll {
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__panel {
-  max-height: 0;
+  height: 0;
   overflow: hidden;
-  visibility: hidden;
-  transition: max-height 220ms ease-in-out, visibility 0s 220ms;
-  padding: 0;
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group.is-open .bw-fpw-discovery-group__panel {
-  max-height: 520px;
+  height: auto; /* JS overrides with measured px during animation */
+}
+
+.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__panel-inner {
   padding: 0 0 8px;
-  visibility: visible;
-  transition: max-height 220ms ease-in-out, visibility 0s;
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group-search {
@@ -2574,7 +2572,7 @@ body.bw-fpw-drawer-no-scroll {
     font-size: 14px;
   }
 
-  .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__panel {
+  .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__panel-inner {
     padding: 0 6px 6px 6px;
   }
 

--- a/assets/css/bw-product-grid.css
+++ b/assets/css/bw-product-grid.css
@@ -2191,8 +2191,24 @@ body.bw-fpw-drawer-no-scroll {
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-mobile-filter-panel__footer--drawer .bw-fpw-mobile-apply--drawer {
   flex: 1 1 auto;
-  width: auto;
+  width: 100%;
   max-width: none;
+}
+
+.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-drawer-clear-all--header {
+  min-height: 44px;
+  padding: 8px 2px;
+  border: none;
+  border-radius: 0;
+  font-size: 13px;
+  font-weight: 500;
+  color: rgba(247, 246, 242, 0.45);
+}
+
+.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-drawer-clear-all--header:hover,
+.bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-drawer-clear-all--header:focus-visible {
+  background: transparent;
+  color: rgba(247, 246, 242, 0.75);
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-mobile-apply--drawer {

--- a/assets/js/bw-product-grid.js
+++ b/assets/js/bw-product-grid.js
@@ -2060,7 +2060,9 @@
             html += '<span class="bw-fpw-discovery-group__chevron" aria-hidden="true">' + chevronIcon + '</span>';
             html += '</button>';
             html += '<div class="bw-fpw-discovery-group__panel" aria-hidden="' + (isOpen ? 'false' : 'true') + '">';
+            html += '<div class="bw-fpw-discovery-group__panel-inner">';
             html += renderDiscoveryYearPanelContent(widgetId, state);
+            html += '</div>';
             html += '</div>';
             html += '</section>';
 
@@ -2073,7 +2075,9 @@
         html += '<span class="bw-fpw-discovery-group__chevron" aria-hidden="true">' + chevronIcon + '</span>';
         html += '</button>';
         html += '<div class="bw-fpw-discovery-group__panel" aria-hidden="' + (isOpen ? 'false' : 'true') + '">';
+        html += '<div class="bw-fpw-discovery-group__panel-inner">';
         html += renderDiscoveryTokenPanelContent(widgetId, state, groupConfig, 'drawer');
+        html += '</div>';
         html += '</div>';
         html += '</section>';
 
@@ -2143,9 +2147,11 @@
                 } else if (nextSelector && $groups.children(nextSelector).length) {
                     $(markup).insertBefore($groups.children(nextSelector).first());
                     $current = $groups.children('.bw-fpw-discovery-group[data-widget-id="' + widgetId + '"][data-group="' + groupKey + '"]');
+                    initAccordionPanelState($current);
                 } else {
                     $groups.append(markup);
                     $current = $groups.children('.bw-fpw-discovery-group[data-widget-id="' + widgetId + '"][data-group="' + groupKey + '"]');
+                    initAccordionPanelState($current);
                 }
             }
 
@@ -2173,6 +2179,65 @@
         });
     }
 
+    function initAccordionPanelState($section) {
+        var $panel = $section.children('.bw-fpw-discovery-group__panel').first();
+        if (!$panel.length) { return; }
+        var panel = $panel[0];
+        var isOpen = $section.hasClass('is-open');
+        $panel.off('transitionend.accordion');
+        panel.style.transition = 'none';
+        if (isOpen) {
+            panel.style.height = 'auto';
+            panel.style.overflow = '';
+            panel.style.visibility = 'visible';
+        } else {
+            panel.style.height = '0';
+            panel.style.overflow = 'hidden';
+            panel.style.visibility = 'hidden';
+        }
+    }
+
+    function animateAccordionPanel($section, open) {
+        var $panel = $section.children('.bw-fpw-discovery-group__panel').first();
+        if (!$panel.length) { return; }
+        var panel = $panel[0];
+        var dur = 320;
+        var easing = 'cubic-bezier(0.22, 1, 0.36, 1)';
+
+        $panel.off('transitionend.accordion');
+        panel.style.transition = 'none';
+
+        if (open) {
+            panel.style.overflow = 'hidden';
+            panel.style.visibility = 'visible';
+            var startH = panel.offsetHeight;
+            var $inner = $panel.children('.bw-fpw-discovery-group__panel-inner');
+            var targetH = ($inner.length ? $inner[0] : panel).scrollHeight;
+            panel.style.height = startH + 'px';
+            panel.offsetHeight;
+            panel.style.transition = 'height ' + dur + 'ms ' + easing;
+            panel.style.height = targetH + 'px';
+            $panel.one('transitionend.accordion', function (e) {
+                if (e.originalEvent.propertyName !== 'height') { return; }
+                panel.style.height = 'auto';
+                panel.style.overflow = '';
+                panel.style.transition = '';
+            });
+        } else {
+            var currentH = panel.offsetHeight;
+            panel.style.height = currentH + 'px';
+            panel.style.overflow = 'hidden';
+            panel.offsetHeight;
+            panel.style.transition = 'height ' + dur + 'ms ' + easing + ', visibility 0s ' + dur + 'ms';
+            panel.style.height = '0';
+            panel.style.visibility = 'hidden';
+            $panel.one('transitionend.accordion', function (e) {
+                if (e.originalEvent.propertyName !== 'height') { return; }
+                panel.style.transition = '';
+            });
+        }
+    }
+
     function applyDiscoveryGroupOpenState(widgetId, groupKey) {
         var state = getDiscoveryState(widgetId);
 
@@ -2194,6 +2259,7 @@
         $section.toggleClass('is-open', isOpen);
         $section.children('.bw-fpw-discovery-group__panel').attr('aria-hidden', isOpen ? 'false' : 'true');
         $section.children('.bw-fpw-discovery-group__toggle').attr('aria-expanded', isOpen ? 'true' : 'false');
+        animateAccordionPanel($section, isOpen);
     }
 
     function getDiscoveryVisibleFilterSummary(state, groupKey) {

--- a/includes/widgets/class-bw-product-grid-widget.php
+++ b/includes/widgets/class-bw-product-grid-widget.php
@@ -1204,9 +1204,7 @@ class BW_Product_Grid_Widget extends Widget_Base {
                                 </div>
                                 <div class="bw-fpw-mobile-filter-drawer-title-row">
                                     <span class="bw-fpw-mobile-filter-drawer-title"><?php echo esc_html( $drawer_title ); ?></span>
-                                    <button class="bw-fpw-mobile-filter-close bw-fpw-drawer-close-btn" type="button" aria-label="<?php esc_attr_e( 'Close filters', 'bw-elementor-widgets' ); ?>">
-                                        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-                                    </button>
+                                    <button class="bw-fpw-drawer-clear-all bw-fpw-drawer-clear-all--header" type="button" data-widget-id="<?php echo esc_attr( $widget_id ); ?>"><?php esc_html_e( 'Clear all', 'bw-elementor-widgets' ); ?></button>
                                 </div>
                             </div>
 
@@ -1218,7 +1216,6 @@ class BW_Product_Grid_Widget extends Widget_Base {
                             </div>
 
                             <div class="bw-fpw-mobile-filter-panel__footer bw-fpw-mobile-filter-panel__footer--drawer">
-                                <button class="bw-fpw-drawer-clear-all" type="button" data-widget-id="<?php echo esc_attr( $widget_id ); ?>"><?php esc_html_e( 'Clear all', 'bw-elementor-widgets' ); ?></button>
                                 <button class="<?php echo esc_attr( implode( ' ', $apply_button_classes ) ); ?>" type="button"><?php echo esc_html( $mobile_show_results ); ?></button>
                             </div>
                         </div>


### PR DESCRIPTION
- Replace max-height:0/520px guess with real scrollHeight measurement
- Add inner wrapper (.bw-fpw-discovery-group__panel-inner) to hold padding; panel itself only controls expand/collapse with no padding shift
- Open: measure scrollHeight → animate height → transitionend sets height:auto
- Close: capture offsetHeight → animate to 0 → visibility:hidden at end
- Cancel any in-flight transition before each new animation
- initAccordionPanelState() sets correct inline height/visibility on DOM insert
- Synchronize chevron easing/duration to match panel: 320ms cubic-bezier(0.22,1,0.36,1)
- Simultaneous open/close when switching sections (both animate independently)