### PR TITLE
Fix accordion title text shift on mobile tap

### DIFF
--- a/assets/css/bw-product-grid.css
+++ b/assets/css/bw-product-grid.css
@@ -1722,15 +1722,16 @@ body.bw-fpw-drawer-no-scroll {
   font-weight: 600;
   line-height: 20px;
   text-align: left;
-  transition: background-color 180ms ease-out, color 180ms ease-out;
+  transition: background-color 180ms ease-out;
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
   user-select: none;
   -webkit-user-select: none;
+  transform: translateZ(0);
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__title {
-  transition: color 180ms ease-out;
+  will-change: auto;
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__toggle:focus-visible {


### PR DESCRIPTION
Remove transition: color from toggle and title elements. On iOS Safari, animating text color changes sub-pixel antialiasing mid-transition, causing the text to visually shift ~1px upward. Color now changes instantly on state change; background-color transition is preserved. Add transform: translateZ(0) to toggle for a stable compositing layer.