### PR TITLE
Fix 5px toggle text shift on Style/Subject accordion open

### DIFF
--- a/assets/css/bw-product-grid.css
+++ b/assets/css/bw-product-grid.css
@@ -1700,7 +1700,6 @@ body.bw-fpw-drawer-no-scroll {
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group {
   border: none;
   color: inherit;
-  overflow: hidden;
   box-shadow: none;
   transition: none;
 }
@@ -1727,7 +1726,7 @@ body.bw-fpw-drawer-no-scroll {
   touch-action: manipulation;
   user-select: none;
   -webkit-user-select: none;
-  transform: translateZ(0);
+  contain: layout;
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__title {
@@ -1801,7 +1800,6 @@ body.bw-fpw-drawer-no-scroll {
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__panel-inner {
   min-height: 0;
-  overflow: hidden;
   padding: 0 0 8px;
 }
 


### PR DESCRIPTION
Root causes:
- overflow: hidden on .bw-fpw-discovery-group created a BFC that interacted badly with will-change: height on the panel, causing GPU layer repositioning
- transform: translateZ(0) on toggle created a compositing layer that shifted when the panel below acquired its own GPU layer on open
- overflow: hidden on __panel-inner could interfere with scrollHeight measurement

Fixes:
- Remove overflow: hidden from .bw-fpw-discovery-group (panel manages its own)
- Replace transform: translateZ(0) with contain: layout on toggle — isolates the toggle's layout from any external changes without GPU layer side effects
- Remove overflow: hidden from __panel-inner (min-height: 0 + panel overflow is sufficient; inner overflow caused potential scrollHeight issues on Safari)