### PR TITLE
Remove contain: layout from accordion toggle - caused row compression

### DIFF
--- a/assets/css/bw-product-grid.css
+++ b/assets/css/bw-product-grid.css
@@ -1726,7 +1726,6 @@ body.bw-fpw-drawer-no-scroll {
   touch-action: manipulation;
   user-select: none;
   -webkit-user-select: none;
-  contain: layout;
 }
 
 .bw-product-grid-wrapper[data-responsive-filter-mode="yes"] .bw-fpw-discovery-group__title {


### PR DESCRIPTION
contain: layout makes the element's min-content/max-content sizes appear as 0 to the grid track sizing algorithm, causing the grid to compress rows above the open panel. The other fixes (overflow:hidden removed from section and panel-inner) are sufficient to prevent the GPU compositing text shift.