### PR TITLE
Allow multiple accordions open simultaneously to prevent toggle shift

### DIFF
--- a/assets/js/bw-product-grid.js
+++ b/assets/js/bw-product-grid.js
@@ -4605,15 +4605,6 @@
 
             var willOpen = !state.ui.openGroups[groupKey];
 
-            if (willOpen) {
-                Object.keys(state.ui.openGroups).forEach(function (key) {
-                    if (key !== groupKey && state.ui.openGroups[key]) {
-                        state.ui.openGroups[key] = false;
-                        applyDiscoveryGroupOpenState(widgetId, key);
-                    }
-                });
-            }
-
             state.ui.openGroups[groupKey] = willOpen;
             applyDiscoveryGroupOpenState(widgetId, groupKey);
         });


### PR DESCRIPTION
Closing other accordions when one opens caused toggle buttons to move upward (avvicinarsi) as the closing animation shrank adjacent sections. Each accordion is now independently toggleable.