### PR TITLE
Fix accordion shift: add align-content: start to drawer content shell

### DIFF
--- a/assets/css/bw-product-grid.css
+++ b/assets/css/bw-product-grid.css
@@ -518,6 +518,7 @@
   display: grid;
   gap: 6px;
   min-height: 100%;
+  align-content: start;
 }
 
 .bw-fpw-filter-option,


### PR DESCRIPTION
CSS Grid default align-content: stretch was redistributing free space between the chips row and the groups row. As accordion content grew, the groups div shifted upward, making all accordion sections appear to move. align-content: start keeps groups anchored at the top.