### PR TITLE
Centralize search popup configuration into single source of truth

### DIFF
--- a/includes/modules/search-surface/adapters/ajax-search-surface.php
+++ b/includes/modules/search-surface/adapters/ajax-search-surface.php
@@ -203,24 +203,18 @@ function bw_ss_build_overlay_advanced_group_items( $scope, $group_key, $query = 
 }
 
 function bw_ss_build_overlay_browse_items( $scope, $group_key, $query = '' ) {
-    $group_key = bw_ss_normalize_overlay_group_key( $group_key, $scope );
+    $group_key   = bw_ss_normalize_overlay_group_key( $group_key, $scope );
+    $definitions = bw_ss_get_group_definitions();
+    $browse_type = isset( $definitions[ $group_key ] ) ? (string) $definitions[ $group_key ]['browse_type'] : '';
 
-    if ( '' === $group_key || 'trending' === $group_key ) {
-        return [];
-    }
-
-    switch ( $group_key ) {
-        case 'categories':
+    switch ( $browse_type ) {
+        case 'category':
             return bw_ss_build_overlay_category_items( $scope, $query );
-        case 'tags':
+        case 'tag':
             return bw_ss_build_overlay_tag_items( $scope, $query );
-        case 'years':
+        case 'year':
             return bw_ss_build_overlay_year_items( $scope, $query );
-        case 'author':
-        case 'artist':
-        case 'publisher':
-        case 'source':
-        case 'technique':
+        case 'advanced':
             return bw_ss_build_overlay_advanced_group_items( $scope, $group_key, $query );
         default:
             return [];

--- a/includes/modules/search-surface/frontend/search-surface-template.php
+++ b/includes/modules/search-surface/frontend/search-surface-template.php
@@ -20,71 +20,44 @@ function bw_ss_should_enqueue_frontend_assets() {
 }
 
 function bw_ss_get_overlay_scope_options() {
-    return [
-        'all'                 => bw_ss_get_scope_label( 'all' ),
-        'digital-collections' => bw_ss_get_scope_label( 'digital-collections' ),
-        'books'               => bw_ss_get_scope_label( 'books' ),
-        'prints'              => bw_ss_get_scope_label( 'prints' ),
-    ];
+    $options = [];
+
+    foreach ( bw_ss_get_scope_definitions() as $scope_key => $scope_def ) {
+        $options[ $scope_key ] = (string) $scope_def['label'];
+    }
+
+    return $options;
 }
 
 function bw_ss_get_overlay_sidebar_groups_map() {
-    return [
-        'all'                 => [
-            [ 'key' => 'trending', 'label' => __( 'Trending', 'bw-elementor-widgets' ) ],
-            [ 'key' => 'categories', 'label' => __( 'Categories', 'bw-elementor-widgets' ) ],
-            [ 'key' => 'tags', 'label' => __( 'Style / Subject', 'bw-elementor-widgets' ) ],
-            [ 'key' => 'years', 'label' => __( 'Year', 'bw-elementor-widgets' ) ],
-        ],
-        'digital-collections' => [
-            [ 'key' => 'trending', 'label' => __( 'Trending', 'bw-elementor-widgets' ) ],
-            [ 'key' => 'categories', 'label' => __( 'Categories', 'bw-elementor-widgets' ) ],
-            [ 'key' => 'source', 'label' => __( 'Sources', 'bw-elementor-widgets' ) ],
-            [ 'key' => 'technique', 'label' => __( 'Technique', 'bw-elementor-widgets' ) ],
-            [ 'key' => 'years', 'label' => __( 'Year', 'bw-elementor-widgets' ) ],
-        ],
-        'books'               => [
-            [ 'key' => 'trending', 'label' => __( 'Trending', 'bw-elementor-widgets' ) ],
-            [ 'key' => 'categories', 'label' => __( 'Categories', 'bw-elementor-widgets' ) ],
-            [ 'key' => 'author', 'label' => __( 'Authors', 'bw-elementor-widgets' ) ],
-            [ 'key' => 'publisher', 'label' => __( 'Publisher', 'bw-elementor-widgets' ) ],
-            [ 'key' => 'years', 'label' => __( 'Year', 'bw-elementor-widgets' ) ],
-        ],
-        'prints'              => [
-            [ 'key' => 'trending', 'label' => __( 'Trending', 'bw-elementor-widgets' ) ],
-            [ 'key' => 'categories', 'label' => __( 'Categories', 'bw-elementor-widgets' ) ],
-            [ 'key' => 'artist', 'label' => __( 'Artists', 'bw-elementor-widgets' ) ],
-            [ 'key' => 'technique', 'label' => __( 'Technique', 'bw-elementor-widgets' ) ],
-            [ 'key' => 'years', 'label' => __( 'Year', 'bw-elementor-widgets' ) ],
-        ],
-    ];
+    $group_definitions = bw_ss_get_group_definitions();
+    $map               = [];
+
+    foreach ( bw_ss_get_scope_definitions() as $scope_key => $scope_def ) {
+        $groups = [];
+
+        foreach ( $scope_def['groups'] as $group_key ) {
+            if ( ! isset( $group_definitions[ $group_key ] ) ) {
+                continue;
+            }
+
+            $groups[] = [
+                'key'   => $group_key,
+                'label' => (string) $group_definitions[ $group_key ]['label'],
+            ];
+        }
+
+        $map[ $scope_key ] = $groups;
+    }
+
+    return $map;
 }
 
 function bw_ss_get_overlay_sidebar_icon_svg( $group_key ) {
-    $group_key = sanitize_key( (string) $group_key );
+    $group_key   = sanitize_key( (string) $group_key );
+    $definitions = bw_ss_get_group_definitions();
 
-    switch ( $group_key ) {
-        case 'trending':
-            return '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M16 7h6v6"/><path d="m22 7-8.5 8.5-5-5L2 17"/></svg>';
-
-        case 'categories':
-            return '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M7 2h10"/><path d="M5 6h14"/><rect width="18" height="12" x="3" y="10" rx="2"/></svg>';
-
-        case 'tags':
-        case 'technique':
-        case 'source':
-        case 'artist':
-            return '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M12 12V4a1 1 0 0 1 1-1h6.297a1 1 0 0 1 .651 1.759l-4.696 4.025"/><path d="m12 21-7.414-7.414A2 2 0 0 1 4 12.172V6.415a1.002 1.002 0 0 1 1.707-.707L20 20.009"/><path d="m12.214 3.381 8.414 14.966a1 1 0 0 1-.167 1.199l-1.168 1.163a1 1 0 0 1-.706.291H6.351a1 1 0 0 1-.625-.219L3.25 18.8a1 1 0 0 1 .631-1.781l4.165.027"/></svg>';
-
-        case 'author':
-        case 'publisher':
-            return '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M12 7v14"/><path d="M16 12h2"/><path d="M16 8h2"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/><path d="M6 12h2"/><path d="M6 8h2"/></svg>';
-
-        case 'years':
-            return '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M16 14v2.2l1.6 1"/><path d="M16 2v4"/><path d="M21 7.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h3.5"/><path d="M3 10h5"/><path d="M8 2v4"/><circle cx="16" cy="16" r="6"/></svg>';
-    }
-
-    return '';
+    return isset( $definitions[ $group_key ] ) ? (string) $definitions[ $group_key ]['icon_svg'] : '';
 }
 
 function bw_ss_enqueue_frontend_assets() {
@@ -119,18 +92,15 @@ function bw_ss_enqueue_frontend_assets() {
             'searchResultsUrl' => bw_ss_get_search_results_url(),
             'scopeOptions'     => bw_ss_get_overlay_scope_options(),
             'sidebarGroups'    => bw_ss_get_overlay_sidebar_groups_map(),
+            'groupIcons'       => bw_ss_get_group_icon_map(),
             'strings'          => [
-                'searchActionLabel'   => __( 'Search for', 'bw-elementor-widgets' ),
-                'searchActionHint'    => __( 'Enter', 'bw-elementor-widgets' ),
-                'suggestionsTitle'    => __( 'Suggested products', 'bw-elementor-widgets' ),
-                'trendingTitle'       => __( 'Trending', 'bw-elementor-widgets' ),
-                'browsePlaceholder'   => __( 'Facet browsing will be expanded in the next milestone.', 'bw-elementor-widgets' ),
-                'emptyBrowse'         => __( 'No values are available for this filter.', 'bw-elementor-widgets' ),
-                'previewTitle'        => __( 'Preview', 'bw-elementor-widgets' ),
-                'previewBody'         => __( 'Start typing to search, or browse a group to refine the next view.', 'bw-elementor-widgets' ),
-                'emptySuggestions'    => __( 'No matching products found.', 'bw-elementor-widgets' ),
-                'emptyTrending'       => __( 'No curated products are available right now.', 'bw-elementor-widgets' ),
-                'loading'             => __( 'Loading…', 'bw-elementor-widgets' ),
+                'searchActionLabel' => __( 'Search for', 'bw-elementor-widgets' ),
+                'searchActionHint'  => __( 'Enter', 'bw-elementor-widgets' ),
+                'browsePlaceholder' => __( 'Facet browsing will be expanded in the next milestone.', 'bw-elementor-widgets' ),
+                'emptyBrowse'       => __( 'No values are available for this filter.', 'bw-elementor-widgets' ),
+                'emptySuggestions'  => __( 'No matching products found.', 'bw-elementor-widgets' ),
+                'emptyTrending'     => __( 'No curated products are available right now.', 'bw-elementor-widgets' ),
+                'loading'           => __( 'Loading…', 'bw-elementor-widgets' ),
             ],
         ]
     );

--- a/includes/modules/search-surface/frontend/search-surface.js
+++ b/includes/modules/search-surface/frontend/search-surface.js
@@ -5,6 +5,7 @@
     var strings = config.strings || {};
     var sidebarGroups = config.sidebarGroups || {};
     var scopeOptions = config.scopeOptions || {};
+    var groupIcons = config.groupIcons || {};
     var openSurface = null;
 
     function getSearchResultsUrl(query, scope) {
@@ -47,45 +48,12 @@
         return scopeOptions[scope] || scopeOptions.all || 'All';
     }
 
-    function getGroupIconSvg(groupKey) {
-        switch (String(groupKey || '')) {
-            case 'trending':
-                return '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M16 7h6v6"></path><path d="m22 7-8.5 8.5-5-5L2 17"></path></svg>';
-            case 'categories':
-                return '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M7 2h10"></path><path d="M5 6h14"></path><rect width="18" height="12" x="3" y="10" rx="2"></rect></svg>';
-            case 'tags':
-            case 'technique':
-            case 'source':
-            case 'artist':
-                return '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M12 12V4a1 1 0 0 1 1-1h6.297a1 1 0 0 1 .651 1.759l-4.696 4.025"></path><path d="m12 21-7.414-7.414A2 2 0 0 1 4 12.172V6.415a1.002 1.002 0 0 1 1.707-.707L20 20.009"></path><path d="m12.214 3.381 8.414 14.966a1 1 0 0 1-.167 1.199l-1.168 1.163a1 1 0 0 1-.706.291H6.351a1 1 0 0 1-.625-.219L3.25 18.8a1 1 0 0 1 .631-1.781l4.165.027"></path></svg>';
-            case 'author':
-            case 'publisher':
-                return '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M12 7v14"></path><path d="M16 12h2"></path><path d="M16 8h2"></path><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"></path><path d="M6 12h2"></path><path d="M6 8h2"></path></svg>';
-            case 'years':
-                return '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M16 14v2.2l1.6 1"></path><path d="M16 2v4"></path><path d="M21 7.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h3.5"></path><path d="M3 10h5"></path><path d="M8 2v4"></path><circle cx="16" cy="16" r="6"></circle></svg>';
-            default:
-                return '';
-        }
-    }
-
     function moveSurfaceToBody(surface) {
         if (!surface || !surface.parentNode || surface.parentNode === document.body) {
             return;
         }
 
         document.body.appendChild(surface);
-    }
-
-    function renderPreview(surfaceState, title, body) {
-        if (!surfaceState.preview) {
-            return;
-        }
-
-        surfaceState.preview.innerHTML =
-            '<div class="bw-search-surface__preview-card">' +
-                '<h3 class="bw-search-surface__preview-title">' + escapeHtml(title) + '</h3>' +
-                '<p class="bw-search-surface__preview-copy">' + escapeHtml(body) + '</p>' +
-            '</div>';
     }
 
     function syncLayoutMode(surfaceState) {
@@ -103,7 +71,7 @@
 
             return (
                 '<button class="bw-search-surface__nav-item' + (isActive ? ' is-active' : '') + '" type="button" data-bw-search-group="' + escapeHtml(group.key) + '">' +
-                    '<span class="bw-search-surface__nav-icon" aria-hidden="true">' + getGroupIconSvg(group.key) + '</span>' +
+                    '<span class="bw-search-surface__nav-icon" aria-hidden="true">' + (groupIcons[group.key] || '') + '</span>' +
                     '<span class="bw-search-surface__nav-label">' + escapeHtml(group.label) + '</span>' +
                 '</button>'
             );
@@ -178,14 +146,7 @@
         }
     }
 
-    function setContentTitle(surfaceState, title) {
-        if (surfaceState.title) {
-            surfaceState.title.textContent = title;
-        }
-    }
-
     function setLoadingState(surfaceState) {
-        setContentTitle(surfaceState, strings.loading || 'Loading…');
         surfaceState.content.innerHTML = '<div class="bw-search-surface__empty">' + escapeHtml(strings.loading || 'Loading…') + '</div>';
     }
 
@@ -196,8 +157,6 @@
         surfaceState.activeGroup = 'trending';
         syncLayoutMode(surfaceState);
         renderSidebar(surfaceState);
-        setContentTitle(surfaceState, strings.trendingTitle || 'Trending');
-        renderPreview(surfaceState, strings.previewTitle || 'Preview', strings.previewBody || '');
 
         if (!rows.length) {
             surfaceState.content.innerHTML = '<div class="bw-search-surface__empty">' + escapeHtml(strings.emptyTrending || 'No curated products are available right now.') + '</div>';
@@ -254,8 +213,6 @@
 
         surfaceState.mode = 'suggest';
         syncLayoutMode(surfaceState);
-        setContentTitle(surfaceState, strings.suggestionsTitle || 'Suggested products');
-        renderPreview(surfaceState, strings.previewTitle || 'Preview', strings.previewBody || '');
 
         if (!items.length) {
             rows.push('<div class="bw-search-surface__empty">' + escapeHtml(strings.emptySuggestions || 'No matching products found.') + '</div>');
@@ -458,8 +415,6 @@
             form: surface.querySelector('[data-bw-search-form]'),
             sidebar: surface.querySelector('[data-bw-search-sidebar]'),
             content: surface.querySelector('[data-bw-search-content]'),
-            preview: surface.querySelector('[data-bw-search-preview]'),
-            title: surface.querySelector('[data-bw-search-title]'),
             scopeInput: surface.querySelector('[data-bw-search-scope-input]'),
             scopeRoot: surface.querySelector('[data-bw-search-scope]'),
             scopeCurrent: surface.querySelector('[data-bw-scope-current]'),
@@ -475,7 +430,6 @@
         };
 
         renderSidebar(surfaceState);
-        renderPreview(surfaceState, strings.previewTitle || 'Preview', strings.previewBody || '');
 
         button.addEventListener('click', function (event) {
             event.preventDefault();

--- a/includes/modules/search-surface/runtime/popup-config.php
+++ b/includes/modules/search-surface/runtime/popup-config.php
@@ -1,0 +1,123 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Single source of truth for search popup group and scope metadata.
+ *
+ * Both PHP rendering and JS (via wp_localize_script) read from these
+ * definitions, eliminating the duplicated SVG switch blocks and scattered
+ * hardcoded arrays that previously lived across search-surface-template.php,
+ * url-state.php, and ajax-search-surface.php.
+ */
+
+function bw_ss_get_group_definitions() {
+    $trending_svg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M16 7h6v6"/><path d="m22 7-8.5 8.5-5-5L2 17"/></svg>';
+
+    $categories_svg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M7 2h10"/><path d="M5 6h14"/><rect width="18" height="12" x="3" y="10" rx="2"/></svg>';
+
+    // Used by: tags, technique, source, artist
+    $tag_svg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M12 12V4a1 1 0 0 1 1-1h6.297a1 1 0 0 1 .651 1.759l-4.696 4.025"/><path d="m12 21-7.414-7.414A2 2 0 0 1 4 12.172V6.415a1.002 1.002 0 0 1 1.707-.707L20 20.009"/><path d="m12.214 3.381 8.414 14.966a1 1 0 0 1-.167 1.199l-1.168 1.163a1 1 0 0 1-.706.291H6.351a1 1 0 0 1-.625-.219L3.25 18.8a1 1 0 0 1 .631-1.781l4.165.027"/></svg>';
+
+    // Used by: author, publisher
+    $book_svg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M12 7v14"/><path d="M16 12h2"/><path d="M16 8h2"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/><path d="M6 12h2"/><path d="M6 8h2"/></svg>';
+
+    $years_svg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M16 14v2.2l1.6 1"/><path d="M16 2v4"/><path d="M21 7.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h3.5"/><path d="M3 10h5"/><path d="M8 2v4"/><circle cx="16" cy="16" r="6"/></svg>';
+
+    return [
+        'trending'   => [
+            'label'       => __( 'Trending', 'bw-elementor-widgets' ),
+            'icon_svg'    => $trending_svg,
+            'param_key'   => '',
+            'browse_type' => '',
+        ],
+        'categories' => [
+            'label'       => __( 'Categories', 'bw-elementor-widgets' ),
+            'icon_svg'    => $categories_svg,
+            'param_key'   => 'category',
+            'browse_type' => 'category',
+        ],
+        'tags'       => [
+            'label'       => __( 'Style / Subject', 'bw-elementor-widgets' ),
+            'icon_svg'    => $tag_svg,
+            'param_key'   => 'tag',
+            'browse_type' => 'tag',
+        ],
+        'years'      => [
+            'label'       => __( 'Year', 'bw-elementor-widgets' ),
+            'icon_svg'    => $years_svg,
+            'param_key'   => 'year',
+            'browse_type' => 'year',
+        ],
+        'source'     => [
+            'label'       => __( 'Sources', 'bw-elementor-widgets' ),
+            'icon_svg'    => $tag_svg,
+            'param_key'   => 'source',
+            'browse_type' => 'advanced',
+        ],
+        'technique'  => [
+            'label'       => __( 'Technique', 'bw-elementor-widgets' ),
+            'icon_svg'    => $tag_svg,
+            'param_key'   => 'technique',
+            'browse_type' => 'advanced',
+        ],
+        'author'     => [
+            'label'       => __( 'Authors', 'bw-elementor-widgets' ),
+            'icon_svg'    => $book_svg,
+            'param_key'   => 'author',
+            'browse_type' => 'advanced',
+        ],
+        'publisher'  => [
+            'label'       => __( 'Publisher', 'bw-elementor-widgets' ),
+            'icon_svg'    => $book_svg,
+            'param_key'   => 'publisher',
+            'browse_type' => 'advanced',
+        ],
+        'artist'     => [
+            'label'       => __( 'Artists', 'bw-elementor-widgets' ),
+            'icon_svg'    => $tag_svg,
+            'param_key'   => 'artist',
+            'browse_type' => 'advanced',
+        ],
+    ];
+}
+
+function bw_ss_get_scope_definitions() {
+    return [
+        'all'                 => [
+            'label'        => __( 'All', 'bw-elementor-widgets' ),
+            'context_slug' => '',
+            'groups'       => [ 'trending', 'categories', 'tags', 'years' ],
+        ],
+        'digital-collections' => [
+            'label'        => __( 'Digital Collections', 'bw-elementor-widgets' ),
+            'context_slug' => 'digital-collections',
+            'groups'       => [ 'trending', 'categories', 'source', 'technique', 'years' ],
+        ],
+        'books'               => [
+            'label'        => __( 'Books', 'bw-elementor-widgets' ),
+            'context_slug' => 'books',
+            'groups'       => [ 'trending', 'categories', 'author', 'publisher', 'years' ],
+        ],
+        'prints'              => [
+            'label'        => __( 'Prints', 'bw-elementor-widgets' ),
+            'context_slug' => 'prints',
+            'groups'       => [ 'trending', 'categories', 'artist', 'technique', 'years' ],
+        ],
+    ];
+}
+
+/**
+ * Returns a flat icon map keyed by group key, for use in wp_localize_script.
+ * Eliminates the duplicate SVG switch block that previously lived in search-surface.js.
+ */
+function bw_ss_get_group_icon_map() {
+    $map = [];
+
+    foreach ( bw_ss_get_group_definitions() as $group_key => $def ) {
+        $map[ $group_key ] = isset( $def['icon_svg'] ) ? (string) $def['icon_svg'] : '';
+    }
+
+    return $map;
+}

--- a/includes/modules/search-surface/runtime/url-state.php
+++ b/includes/modules/search-surface/runtime/url-state.php
@@ -78,17 +78,9 @@ function bw_ss_normalize_scope_param( $raw_scope ) {
 }
 
 function bw_ss_get_scope_label( $scope ) {
-    switch ( $scope ) {
-        case 'digital-collections':
-            return __( 'Digital Collections', 'bw-elementor-widgets' );
-        case 'books':
-            return __( 'Books', 'bw-elementor-widgets' );
-        case 'prints':
-            return __( 'Prints', 'bw-elementor-widgets' );
-        case 'all':
-        default:
-            return __( 'All', 'bw-elementor-widgets' );
-    }
+    $definitions = bw_ss_get_scope_definitions();
+
+    return isset( $definitions[ $scope ] ) ? (string) $definitions[ $scope ]['label'] : (string) $definitions['all']['label'];
 }
 
 function bw_ss_get_scope_context_slug( $scope ) {
@@ -117,22 +109,10 @@ function bw_ss_get_scope_default_category( $scope ) {
 }
 
 function bw_ss_get_filter_param_key_for_group( $group_key ) {
-    switch ( sanitize_key( (string) $group_key ) ) {
-        case 'categories':
-            return 'category';
-        case 'tags':
-            return 'tag';
-        case 'years':
-            return 'year';
-        case 'author':
-        case 'artist':
-        case 'publisher':
-        case 'source':
-        case 'technique':
-            return sanitize_key( (string) $group_key );
-        default:
-            return '';
-    }
+    $group_key   = sanitize_key( (string) $group_key );
+    $definitions = bw_ss_get_group_definitions();
+
+    return isset( $definitions[ $group_key ] ) ? (string) $definitions[ $group_key ]['param_key'] : '';
 }
 
 function bw_ss_parse_query_value_list( $raw_value ) {

--- a/includes/modules/search-surface/search-surface-module.php
+++ b/includes/modules/search-surface/search-surface-module.php
@@ -7,6 +7,7 @@ if ( ! defined( 'BW_SS_REWRITE_VERSION' ) ) {
     define( 'BW_SS_REWRITE_VERSION', '1' );
 }
 
+require_once __DIR__ . '/runtime/popup-config.php';
 require_once __DIR__ . '/runtime/url-state.php';
 require_once __DIR__ . '/../search-engine/engine/sort-config.php';
 require_once __DIR__ . '/runtime/headless-product-grid-renderer.php';


### PR DESCRIPTION
## Summary
Consolidates scattered popup group and scope metadata definitions across multiple files into a single centralized configuration module, eliminating code duplication and improving maintainability.

## Key Changes
- **New file**: `popup-config.php` - Introduces `bw_ss_get_group_definitions()` and `bw_ss_get_scope_definitions()` functions that serve as the single source of truth for all popup configuration metadata
- **Removed duplicate SVG definitions**: Eliminated hardcoded SVG switch blocks from `search-surface-template.php` and `search-surface.js`
- **Removed duplicate scope/group mappings**: Replaced scattered hardcoded arrays in `search-surface-template.php` with dynamic generation from centralized definitions
- **Simplified URL state handling**: Refactored `url-state.php` to use group/scope definitions instead of switch statements
- **Updated AJAX adapter**: Modified `ajax-search-surface.php` to use `browse_type` from definitions instead of direct group key matching
- **Cleaned up JavaScript**: Removed `getGroupIconSvg()` function from `search-surface.js` and replaced with data passed via `wp_localize_script`
- **Removed unused UI elements**: Eliminated preview card rendering and title management code from JavaScript

## Implementation Details
- Group definitions include: label, icon SVG, parameter key, and browse type
- Scope definitions include: label, context slug, and list of applicable groups
- New helper function `bw_ss_get_group_icon_map()` provides flat icon mapping for JavaScript consumption
- All configuration is now loaded once at module initialization and passed to frontend via `wp_localize_script`
- Maintains backward compatibility with existing URL parameter handling and AJAX endpoints

https://claude.ai/code/session_01Ai5qtD3yAHVgwApTLYCi3h