### PR TITLE
Phase 2: search popup UI cleanup and accessibility fixes

### DIFF
--- a/includes/modules/search-surface/frontend/search-surface-template.php
+++ b/includes/modules/search-surface/frontend/search-surface-template.php
@@ -199,7 +199,8 @@ function bw_ss_render_search_surface_template( $overlay_args = [] ) {
                 </aside>
 
                 <section class="bw-search-surface__main">
-                    <div class="bw-search-surface__content" data-bw-search-content>
+                    <div class="bw-search-surface__content-header" data-bw-search-content-header hidden></div>
+                    <div class="bw-search-surface__content" data-bw-search-content aria-live="polite">
                         <div class="bw-search-surface__empty"><?php esc_html_e( 'Loading…', 'bw-elementor-widgets' ); ?></div>
                     </div>
                 </section>

--- a/includes/modules/search-surface/frontend/search-surface.css
+++ b/includes/modules/search-surface/frontend/search-surface.css
@@ -529,8 +529,7 @@ body.bw-search-overlay-active {
 }
 
 .bw-search-surface__sidebar,
-.bw-search-surface__main,
-.bw-search-surface__preview {
+.bw-search-surface__main {
     min-width: 0;
     min-height: 0;
 }
@@ -617,17 +616,18 @@ body.bw-search-overlay-active {
     background: rgba(255, 255, 255, 0.012);
 }
 
-.bw-search-surface__section-header {
-    margin-bottom: 18px;
+.bw-search-surface__content-header {
+    flex: 0 0 auto;
+    padding-bottom: 12px;
+    font-size: 0.82rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--bw-search-surface-text-soft) !important;
 }
 
-.bw-search-surface__title,
-.bw-search-surface__section-title {
-    margin: 0;
-    font-size: 1.2rem;
-    line-height: 1.2;
-    color: #ffffff !important;
-    font-weight: 700;
+.bw-search-surface__content-header[hidden] {
+    display: none;
 }
 
 .bw-search-surface__content {
@@ -705,13 +705,6 @@ body.bw-search-overlay-active {
     font-size: 0.94rem;
     font-weight: 500;
     text-align: right;
-}
-
-.bw-search-surface__row-title {
-    font-size: 0.88rem;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    color: var(--bw-search-surface-text-soft) !important;
 }
 
 .bw-search-surface__action-row,
@@ -859,48 +852,14 @@ body.bw-search-overlay-active {
     font-size: 0.86rem;
 }
 
-.bw-search-surface__preview {
-    padding: 22px;
-    border-left: 1px solid rgba(255, 255, 255, 0.05);
-    background: rgba(255, 255, 255, 0.03);
-    overflow: auto;
-    overscroll-behavior: contain;
-}
-
-.bw-search-surface__preview-card {
-    padding: 18px;
-    border-radius: 20px;
-    background: rgba(255, 255, 255, 0.045);
-    border: 1px solid rgba(255, 255, 255, 0.07);
-}
-
-.bw-search-surface__preview-title {
-    margin: 0 0 10px;
-    font-size: 1rem;
-    color: #ffffff !important;
-    font-weight: 700;
-}
-
-.bw-search-surface__preview-copy {
-    margin: 0;
-    color: rgba(250, 250, 250, 0.64) !important;
-    line-height: 1.55;
-}
-
-.bw-search-surface .bw-search-surface__dialog .bw-search-surface__title,
-.bw-search-surface .bw-search-surface__dialog .bw-search-surface__section-title,
 .bw-search-surface .bw-search-surface__dialog .bw-search-surface__trending-title,
 .bw-search-surface .bw-search-surface__dialog .bw-search-surface__row-title-text,
-.bw-search-surface .bw-search-surface__dialog .bw-search-surface__preview-title,
 .bw-search-surface .bw-search-surface__dialog .bw-search-surface__nav-label,
-.bw-search-surface .bw-search-surface__dialog h1.bw-search-surface__title,
-.bw-search-surface .bw-search-surface__dialog h2.bw-search-surface__section-title,
 .bw-search-surface .bw-search-surface__dialog h3.bw-search-surface__trending-title {
     color: #ffffff !important;
 }
 
 .bw-search-surface .bw-search-surface__dialog .bw-search-surface__row-meta,
-.bw-search-surface .bw-search-surface__dialog .bw-search-surface__preview-copy,
 .bw-search-surface .bw-search-surface__dialog .bw-search-surface__empty,
 .bw-search-surface .bw-search-surface__dialog .bw-search-surface__row-action,
 .bw-search-surface .bw-search-surface__dialog .bw-search-surface__facet-count {

--- a/includes/modules/search-surface/frontend/search-surface.js
+++ b/includes/modules/search-surface/frontend/search-surface.js
@@ -135,6 +135,9 @@
         window.clearTimeout(surfaceState.debounceTimer);
         surfaceState.surface.classList.remove('is-open');
         surfaceState.scopeRoot.classList.remove('is-open');
+        if (surfaceState.scopeTrigger) {
+            surfaceState.scopeTrigger.setAttribute('aria-expanded', 'false');
+        }
         surfaceState.query = '';
         surfaceState.activeGroup = 'trending';
         surfaceState.input.value = '';
@@ -146,7 +149,21 @@
         }
     }
 
+    function setContentHeader(surfaceState, text) {
+        if (!surfaceState.contentHeader) {
+            return;
+        }
+
+        if (text) {
+            surfaceState.contentHeader.textContent = text;
+            surfaceState.contentHeader.hidden = false;
+        } else {
+            surfaceState.contentHeader.hidden = true;
+        }
+    }
+
     function setLoadingState(surfaceState) {
+        setContentHeader(surfaceState, '');
         surfaceState.content.innerHTML = '<div class="bw-search-surface__empty">' + escapeHtml(strings.loading || 'Loading…') + '</div>';
     }
 
@@ -157,6 +174,7 @@
         surfaceState.activeGroup = 'trending';
         syncLayoutMode(surfaceState);
         renderSidebar(surfaceState);
+        setContentHeader(surfaceState, getScopeLabel(surfaceState.scope));
 
         if (!rows.length) {
             surfaceState.content.innerHTML = '<div class="bw-search-surface__empty">' + escapeHtml(strings.emptyTrending || 'No curated products are available right now.') + '</div>';
@@ -198,7 +216,7 @@
         var query = surfaceState.query;
         var searchUrl = payload.search_url || getSearchResultsUrl(query, surfaceState.scope);
         var actionLabel = (strings.searchActionLabel || 'Search for') + ' "' + query + '"';
-        var rows = [
+        var actionRow =
             '<a class="bw-search-surface__action-row" href="' + escapeHtml(searchUrl) + '" data-bw-search-action-link>' +
                 '<span class="bw-search-surface__action-icon" aria-hidden="true">' +
                     '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="11" cy="11" r="7"></circle><path d="M20 20L16.65 16.65"></path></svg>' +
@@ -208,24 +226,25 @@
                     '<span class="bw-search-surface__row-meta">' + escapeHtml(getScopeLabel(surfaceState.scope)) + '</span>' +
                 '</span>' +
                 '<span class="bw-search-surface__row-action">' + escapeHtml(strings.searchActionHint || 'Enter') + '</span>' +
-            '</a>'
-        ];
+            '</a>';
 
         surfaceState.mode = 'suggest';
         syncLayoutMode(surfaceState);
+        setContentHeader(surfaceState, '');
 
         if (!items.length) {
-            rows.push('<div class="bw-search-surface__empty">' + escapeHtml(strings.emptySuggestions || 'No matching products found.') + '</div>');
-            surfaceState.content.innerHTML = '<div class="bw-search-surface__row-group">' + rows.join('') + '</div>';
+            surfaceState.content.innerHTML =
+                '<div class="bw-search-surface__row-group">' + actionRow + '</div>' +
+                '<div class="bw-search-surface__empty">' + escapeHtml(strings.emptySuggestions || 'No matching products found.') + '</div>';
             return;
         }
 
-        items.forEach(function (item) {
+        var suggestRows = items.map(function (item) {
             var imageHtml = item.image_url
                 ? '<div class="bw-search-surface__suggestion-media"><img src="' + escapeHtml(item.image_url) + '" alt="' + escapeHtml(item.title) + '" loading="lazy"></div>'
                 : '<div class="bw-search-surface__suggestion-media"></div>';
 
-            rows.push(
+            return (
                 '<a class="bw-search-surface__suggestion-row" href="' + escapeHtml(item.permalink) + '">' +
                     imageHtml +
                     '<span class="bw-search-surface__row-body">' +
@@ -235,9 +254,9 @@
                     '<span class="bw-search-surface__row-action"></span>' +
                 '</a>'
             );
-        });
+        }).join('');
 
-        surfaceState.content.innerHTML = '<div class="bw-search-surface__row-group">' + rows.join('') + '</div>';
+        surfaceState.content.innerHTML = '<div class="bw-search-surface__row-group">' + actionRow + suggestRows + '</div>';
     }
 
     function renderBrowse(surfaceState, groupKey, payload) {
@@ -258,6 +277,7 @@
         surfaceState.activeGroup = groupKey;
         syncLayoutMode(surfaceState);
         renderSidebar(surfaceState);
+        setContentHeader(surfaceState, active ? active.label : '');
 
         if (!items.length) {
             surfaceState.content.innerHTML = '<div class="bw-search-surface__empty">' + escapeHtml(strings.emptyBrowse || 'No values are available for this filter.') + '</div>';
@@ -415,7 +435,9 @@
             form: surface.querySelector('[data-bw-search-form]'),
             sidebar: surface.querySelector('[data-bw-search-sidebar]'),
             content: surface.querySelector('[data-bw-search-content]'),
+            contentHeader: surface.querySelector('[data-bw-search-content-header]'),
             scopeInput: surface.querySelector('[data-bw-search-scope-input]'),
+            scopeTrigger: surface.querySelector('[data-bw-scope-toggle]'),
             scopeRoot: surface.querySelector('[data-bw-search-scope]'),
             scopeCurrent: surface.querySelector('[data-bw-scope-current]'),
             scopeMenu: surface.querySelector('[data-bw-scope-menu]'),
@@ -474,6 +496,9 @@
             if (scopeButton) {
                 event.preventDefault();
                 surfaceState.scopeRoot.classList.remove('is-open');
+                if (surfaceState.scopeTrigger) {
+                    surfaceState.scopeTrigger.setAttribute('aria-expanded', 'false');
+                }
                 setScope(surfaceState, scopeButton.getAttribute('data-bw-scope-option'));
                 return;
             }
@@ -481,6 +506,9 @@
             if (event.target.closest('[data-bw-scope-toggle]')) {
                 event.preventDefault();
                 surfaceState.scopeRoot.classList.toggle('is-open');
+                if (surfaceState.scopeTrigger) {
+                    surfaceState.scopeTrigger.setAttribute('aria-expanded', surfaceState.scopeRoot.classList.contains('is-open') ? 'true' : 'false');
+                }
             }
         });
 
@@ -495,6 +523,9 @@
 
         if (!event.target.closest('[data-bw-scope-toggle]') && !event.target.closest('[data-bw-scope-menu]')) {
             openSurface.scopeRoot.classList.remove('is-open');
+            if (openSurface.scopeTrigger) {
+                openSurface.scopeTrigger.setAttribute('aria-expanded', 'false');
+            }
         }
     });
 


### PR DESCRIPTION
Content header: add data-bw-search-content-header element in the main panel; wire setContentHeader() in JS to show the scope label in trending mode and the group label in browse mode, hidden in suggest/loading. This gives browse mode a visible title showing what facet is being viewed.

Suggest mode: separate the empty-state div from the action-row wrapper so empty text renders outside the card group (cleaner grid layout).

aria-expanded: fix scope trigger button — JS now syncs the attribute whenever the scope menu opens, closes, or the dialog closes. Previously aria-expanded was set in PHP and never updated by JS.

aria-live: add aria-live="polite" to the content region so screen readers announce content updates on mode changes.

CSS dead code: remove ~60 lines — preview block (__preview, __preview-card, __preview-title, __preview-copy), old section-header and __title/__section-title rules, dead __row-title rule, and all preview references in the theme-override selectors. Trim the __preview entry from the shared min-width/min-height rule.