### PR TITLE
Redesign search popup: 5-mode sidebar with full filter panel

### DIFF
--- a/includes/modules/search-surface/adapters/ajax-search-surface.php
+++ b/includes/modules/search-surface/adapters/ajax-search-surface.php
@@ -35,192 +35,6 @@ function bw_ss_normalize_overlay_group_key( $group_key, $scope = 'all' ) {
     return '';
 }
 
-function bw_ss_get_overlay_candidate_post_ids( $scope, $query = '' ) {
-    $scope        = bw_ss_normalize_scope_param( $scope );
-    $context_slug = bw_ss_get_scope_context_slug( $scope );
-    $category     = bw_ss_get_scope_default_category( $scope );
-    $search       = function_exists( 'bw_fpw_normalize_search_query' )
-        ? bw_fpw_normalize_search_query( $query )
-        : sanitize_text_field( (string) $query );
-
-    if ( '' !== $search && function_exists( 'bw_fpw_get_matching_post_ids' ) ) {
-        return bw_fpw_get_matching_post_ids( 'product', $category, [], [], $search, null, null, $context_slug, [] );
-    }
-
-    if ( function_exists( 'bw_fpw_get_candidate_post_ids_without_search' ) ) {
-        return bw_fpw_get_candidate_post_ids_without_search( 'product', $category, [], [], null, null, $context_slug, [] );
-    }
-
-    return [];
-}
-
-function bw_ss_build_overlay_category_items( $scope, $query = '' ) {
-    $scope        = bw_ss_normalize_scope_param( $scope );
-    $context_slug = bw_ss_get_scope_context_slug( $scope );
-    $category     = bw_ss_get_scope_default_category( $scope );
-    $items        = function_exists( 'bw_fpw_get_available_subcategories_data' )
-        ? bw_fpw_get_available_subcategories_data( 'product', $category, [], $query, null, null, $context_slug, [] )
-        : [];
-    $results      = [];
-
-    foreach ( (array) $items as $item ) {
-        $term = get_term( isset( $item['term_id'] ) ? (int) $item['term_id'] : 0, 'product_cat' );
-
-        if ( ! $term instanceof WP_Term || is_wp_error( $term ) ) {
-            continue;
-        }
-
-        $results[] = [
-            'label' => $term->name,
-            'count' => isset( $item['count'] ) ? (int) $item['count'] : 0,
-            'url'   => bw_ss_build_search_results_navigation_url(
-                $query,
-                $scope,
-                [ 'category' => $term->slug ]
-            ),
-        ];
-    }
-
-    return $results;
-}
-
-function bw_ss_build_overlay_tag_items( $scope, $query = '' ) {
-    $scope        = bw_ss_normalize_scope_param( $scope );
-    $context_slug = bw_ss_get_scope_context_slug( $scope );
-    $category     = bw_ss_get_scope_default_category( $scope );
-    $items        = function_exists( 'bw_fpw_get_related_tags_data' )
-        ? bw_fpw_get_related_tags_data( 'product', $category, [], $query, null, null, $context_slug, [] )
-        : [];
-    $results      = [];
-
-    foreach ( (array) $items as $item ) {
-        $term = get_term( isset( $item['term_id'] ) ? (int) $item['term_id'] : 0, 'product_tag' );
-
-        if ( ! $term instanceof WP_Term || is_wp_error( $term ) ) {
-            continue;
-        }
-
-        $results[] = [
-            'label' => $term->name,
-            'count' => isset( $item['count'] ) ? (int) $item['count'] : 0,
-            'url'   => bw_ss_build_search_results_navigation_url(
-                $query,
-                $scope,
-                [ 'tag' => $term->slug ]
-            ),
-        ];
-    }
-
-    return $results;
-}
-
-function bw_ss_build_overlay_year_items( $scope, $query = '' ) {
-    $scope        = bw_ss_normalize_scope_param( $scope );
-    $context_slug = bw_ss_get_scope_context_slug( $scope );
-    $search       = function_exists( 'bw_fpw_normalize_search_query' )
-        ? bw_fpw_normalize_search_query( $query )
-        : sanitize_text_field( (string) $query );
-    $counts       = [];
-
-    if ( '' === $search && function_exists( 'bw_fpw_get_year_index' ) ) {
-        $year_index = bw_fpw_get_year_index( $context_slug );
-        $counts     = isset( $year_index['years'] ) && is_array( $year_index['years'] ) ? $year_index['years'] : [];
-    } elseif ( function_exists( 'bw_fpw_get_year_postmap' ) ) {
-        $post_map = bw_fpw_get_year_postmap( $context_slug );
-
-        foreach ( bw_ss_get_overlay_candidate_post_ids( $scope, $query ) as $post_id ) {
-            $year = isset( $post_map[ $post_id ] ) ? (int) $post_map[ $post_id ] : 0;
-
-            if ( $year <= 0 ) {
-                continue;
-            }
-
-            if ( ! isset( $counts[ $year ] ) ) {
-                $counts[ $year ] = 0;
-            }
-
-            $counts[ $year ]++;
-        }
-    }
-
-    if ( empty( $counts ) ) {
-        return [];
-    }
-
-    krsort( $counts, SORT_NUMERIC );
-    $results = [];
-
-    foreach ( $counts as $year => $count ) {
-        $results[] = [
-            'label' => (string) $year,
-            'count' => (int) $count,
-            'url'   => bw_ss_build_search_results_navigation_url(
-                $query,
-                $scope,
-                [ 'year' => (string) $year ]
-            ),
-        ];
-    }
-
-    return array_values( $results );
-}
-
-function bw_ss_build_overlay_advanced_group_items( $scope, $group_key, $query = '' ) {
-    $scope        = bw_ss_normalize_scope_param( $scope );
-    $context_slug = bw_ss_get_scope_context_slug( $scope );
-    $group_key    = sanitize_key( (string) $group_key );
-
-    if ( '' === $context_slug || ! function_exists( 'bw_fpw_get_supported_advanced_filter_groups_for_context' ) ) {
-        return [];
-    }
-
-    $supported = bw_fpw_get_supported_advanced_filter_groups_for_context( $context_slug );
-
-    if ( ! isset( $supported[ $group_key ] ) || ! function_exists( 'bw_fpw_build_advanced_filter_options_from_post_ids' ) ) {
-        return [];
-    }
-
-    $results = [];
-    $items   = bw_fpw_build_advanced_filter_options_from_post_ids( $context_slug, $group_key, bw_ss_get_overlay_candidate_post_ids( $scope, $query ) );
-
-    foreach ( (array) $items as $item ) {
-        if ( empty( $item['name'] ) ) {
-            continue;
-        }
-
-        $results[] = [
-            'label' => (string) $item['name'],
-            'count' => isset( $item['count'] ) ? (int) $item['count'] : 0,
-            'url'   => bw_ss_build_search_results_navigation_url(
-                $query,
-                $scope,
-                [ $group_key => bw_ss_build_filter_value_slug( $item['name'] ) ]
-            ),
-        ];
-    }
-
-    return $results;
-}
-
-function bw_ss_build_overlay_browse_items( $scope, $group_key, $query = '' ) {
-    $group_key   = bw_ss_normalize_overlay_group_key( $group_key, $scope );
-    $definitions = bw_ss_get_group_definitions();
-    $browse_type = isset( $definitions[ $group_key ] ) ? (string) $definitions[ $group_key ]['browse_type'] : '';
-
-    switch ( $browse_type ) {
-        case 'category':
-            return bw_ss_build_overlay_category_items( $scope, $query );
-        case 'tag':
-            return bw_ss_build_overlay_tag_items( $scope, $query );
-        case 'year':
-            return bw_ss_build_overlay_year_items( $scope, $query );
-        case 'advanced':
-            return bw_ss_build_overlay_advanced_group_items( $scope, $group_key, $query );
-        default:
-            return [];
-    }
-}
-
 function bw_ss_build_overlay_suggestions( $page_post_ids ) {
     $suggestions = [];
 
@@ -235,17 +49,143 @@ function bw_ss_build_overlay_suggestions( $page_post_ids ) {
     return $suggestions;
 }
 
+/**
+ * Build the filter UI payload for the popup Filter mode.
+ * Executes a minimal engine request to retrieve available facets for a given scope.
+ */
+function bw_ss_build_popup_filter_ui_payload( $scope ) {
+    $empty = [
+        'types'        => [],
+        'tags'         => [],
+        'year'         => [ 'supported' => false ],
+        'advanced'     => [],
+        'result_count' => 0,
+        'context'      => '',
+        'scope'        => $scope,
+    ];
+
+    if ( ! function_exists( 'bw_fpw_build_engine_request' ) || ! function_exists( 'bw_fpw_execute_search' ) ) {
+        return $empty;
+    }
+
+    $context_slug = bw_ss_get_scope_context_slug( $scope );
+    $category     = bw_ss_get_scope_default_category( $scope );
+    $sort_key     = function_exists( 'bw_fpw_get_discovery_sort_default_key' ) ? bw_fpw_get_discovery_sort_default_key() : 'newest';
+
+    $request = bw_fpw_build_engine_request(
+        [
+            'widget_id'        => 'bw-search-surface-filter',
+            'post_type'        => 'product',
+            'context_slug'     => $context_slug,
+            'category'         => $category,
+            'subcategories'    => [],
+            'tags'             => [],
+            'search_enabled'   => 'no',
+            'search'           => '',
+            'per_page'         => 1,
+            'page'             => 1,
+            'offset'           => 0,
+            'request_profile'  => 'filter_ui',
+            'sort_key'         => $sort_key,
+            'order_by'         => 'date',
+            'order'            => 'DESC',
+        ]
+    );
+
+    $result    = bw_fpw_execute_search( $request );
+    $filter_ui = isset( $result['filter_ui'] ) && is_array( $result['filter_ui'] ) ? $result['filter_ui'] : [];
+
+    return [
+        'types'        => isset( $filter_ui['types'] ) ? array_values( (array) $filter_ui['types'] ) : [],
+        'tags'         => isset( $filter_ui['tags'] ) ? array_values( (array) $filter_ui['tags'] ) : [],
+        'year'         => isset( $filter_ui['year'] ) ? $filter_ui['year'] : [ 'supported' => false ],
+        'advanced'     => isset( $filter_ui['advanced'] ) ? $filter_ui['advanced'] : [],
+        'result_count' => isset( $result['result_count'] ) ? (int) $result['result_count'] : 0,
+        'context'      => $context_slug ?: 'mixed',
+        'scope'        => $scope,
+    ];
+}
+
+/**
+ * Execute a filtered count-only search for popup filter live count updates.
+ */
+function bw_ss_get_popup_filter_result_count( $scope, $post_data ) {
+    if ( ! function_exists( 'bw_fpw_build_engine_request' ) || ! function_exists( 'bw_fpw_execute_search' ) ) {
+        return 0;
+    }
+
+    $context_slug = bw_ss_get_scope_context_slug( $scope );
+    $category     = bw_ss_get_scope_default_category( $scope );
+    $sort_key     = function_exists( 'bw_fpw_get_discovery_sort_default_key' ) ? bw_fpw_get_discovery_sort_default_key() : 'newest';
+
+    $raw_subs      = isset( $post_data['subcategories'] ) ? wp_unslash( $post_data['subcategories'] ) : '';
+    $subcategories = array_values( array_filter( array_map( 'absint', explode( ',', (string) $raw_subs ) ) ) );
+
+    $raw_tags = isset( $post_data['tags'] ) ? wp_unslash( $post_data['tags'] ) : '';
+    $tags     = array_values( array_filter( array_map( 'absint', explode( ',', (string) $raw_tags ) ) ) );
+
+    $year_from = ! empty( $post_data['year_from'] ) ? absint( wp_unslash( $post_data['year_from'] ) ) : null;
+    $year_to   = ! empty( $post_data['year_to'] ) ? absint( wp_unslash( $post_data['year_to'] ) ) : null;
+
+    $advanced_keys = [ 'artist', 'author', 'publisher', 'source', 'technique' ];
+    $advanced      = [];
+
+    foreach ( $advanced_keys as $key ) {
+        if ( empty( $post_data[ $key ] ) ) {
+            continue;
+        }
+
+        $raw_values = array_filter( explode( ',', sanitize_text_field( wp_unslash( (string) $post_data[ $key ] ) ) ) );
+        $tokens     = [];
+
+        foreach ( $raw_values as $slug ) {
+            $label    = trim( str_replace( '-', ' ', sanitize_text_field( $slug ) ) );
+            $tokens[] = $label;
+        }
+
+        $advanced[ $key ] = $tokens;
+    }
+
+    $request = bw_fpw_build_engine_request(
+        [
+            'widget_id'       => 'bw-search-surface-filter-count',
+            'post_type'       => 'product',
+            'context_slug'    => $context_slug,
+            'category'        => $category,
+            'subcategories'   => $subcategories,
+            'tags'            => $tags,
+            'search_enabled'  => 'no',
+            'search'          => '',
+            'year_from'       => $year_from,
+            'year_to'         => $year_to,
+            'artist'          => $advanced['artist'] ?? [],
+            'author'          => $advanced['author'] ?? [],
+            'publisher'       => $advanced['publisher'] ?? [],
+            'source'          => $advanced['source'] ?? [],
+            'technique'       => $advanced['technique'] ?? [],
+            'per_page'        => 1,
+            'page'            => 1,
+            'offset'          => 0,
+            'request_profile' => 'count_only',
+            'sort_key'        => $sort_key,
+            'order_by'        => 'date',
+            'order'           => 'DESC',
+        ]
+    );
+
+    $result = bw_fpw_execute_search( $request );
+
+    return isset( $result['result_count'] ) ? (int) $result['result_count'] : 0;
+}
+
 function bw_ss_send_overlay_throttled_response( $mode, $scope, $query ) {
     wp_send_json_success(
         [
-            'mode'       => sanitize_key( (string) $mode ),
-            'scope'      => bw_ss_normalize_scope_param( $scope ),
-            'query'      => function_exists( 'bw_fpw_normalize_search_query' ) ? bw_fpw_normalize_search_query( $query ) : sanitize_text_field( (string) $query ),
-            'throttled'  => true,
-            'search_url' => bw_ss_build_search_results_navigation_url( $query, $scope ),
-            'rows'       => [],
-            'items'      => [],
-            'group'      => '',
+            'mode'      => sanitize_key( (string) $mode ),
+            'scope'     => bw_ss_normalize_scope_param( $scope ),
+            'query'     => function_exists( 'bw_fpw_normalize_search_query' ) ? bw_fpw_normalize_search_query( $query ) : sanitize_text_field( (string) $query ),
+            'throttled' => true,
+            'items'     => [],
         ]
     );
 }
@@ -255,7 +195,6 @@ function bw_ss_ajax_overlay_payload() {
 
     $mode  = sanitize_key( isset( $_POST['mode'] ) ? wp_unslash( $_POST['mode'] ) : 'trending' );
     $scope = bw_ss_normalize_scope_param( isset( $_POST['scope'] ) ? wp_unslash( $_POST['scope'] ) : 'all' );
-    $group = bw_ss_normalize_overlay_group_key( isset( $_POST['group'] ) ? wp_unslash( $_POST['group'] ) : '', $scope );
     $query = function_exists( 'bw_fpw_normalize_search_query' )
         ? bw_fpw_normalize_search_query( isset( $_POST['query'] ) ? wp_unslash( $_POST['query'] ) : '' )
         : sanitize_text_field( (string) ( $_POST['query'] ?? '' ) );
@@ -264,41 +203,76 @@ function bw_ss_ajax_overlay_payload() {
         bw_ss_send_overlay_throttled_response( $mode, $scope, $query );
     }
 
+    // ── Suggest mode ──────────────────────────────────────────────────────────
     if ( 'suggest' === $mode && '' !== $query ) {
         $request = bw_ss_build_overlay_suggest_request( $query, $scope );
         $result  = bw_fpw_execute_search( $request );
 
         wp_send_json_success(
             [
-                'mode'       => 'suggest',
-                'scope'      => $scope,
-                'query'      => $query,
-                'search_url' => bw_ss_build_search_results_navigation_url( $query, $scope ),
-                'items'      => bw_ss_build_overlay_suggestions( isset( $result['page_post_ids'] ) ? $result['page_post_ids'] : [] ),
-                'has_more'   => ! empty( $result['has_more'] ),
+                'mode'         => 'suggest',
+                'scope'        => $scope,
+                'query'        => $query,
+                'search_url'   => bw_ss_build_search_results_navigation_url( $query, $scope ),
+                'items'        => bw_ss_build_overlay_suggestions( isset( $result['page_post_ids'] ) ? $result['page_post_ids'] : [] ),
+                'has_more'     => ! empty( $result['has_more'] ),
+                'result_count' => isset( $result['result_count'] ) ? (int) $result['result_count'] : 0,
             ]
         );
     }
 
-    if ( 'browse' === $mode && '' !== $group ) {
+    // ── Filter mode ───────────────────────────────────────────────────────────
+    if ( 'filter' === $mode ) {
         wp_send_json_success(
             [
-                'mode'       => 'browse',
-                'scope'      => $scope,
-                'group'      => $group,
-                'query'      => $query,
-                'search_url' => bw_ss_build_search_results_navigation_url( $query, $scope ),
-                'items'      => bw_ss_build_overlay_browse_items( $scope, $group, $query ),
+                'mode'      => 'filter',
+                'scope'     => $scope,
+                'filter_ui' => bw_ss_build_popup_filter_ui_payload( $scope ),
             ]
         );
     }
+
+    // ── Filter count mode ─────────────────────────────────────────────────────
+    if ( 'filter_count' === $mode ) {
+        wp_send_json_success(
+            [
+                'mode'  => 'filter_count',
+                'count' => bw_ss_get_popup_filter_result_count( $scope, $_POST ),
+            ]
+        );
+    }
+
+    // ── Feed modes: trending (staff-selected), new, sale, free ───────────────
+    $feed_label_map = [
+        'trending' => 'staff_select',
+        'new'      => 'new',
+        'sale'     => 'sale',
+        'free'     => 'free_download',
+    ];
+
+    if ( isset( $feed_label_map[ $mode ] ) ) {
+        $label_key   = $feed_label_map[ $mode ];
+        $settings    = function_exists( 'bw_get_product_labels_settings' ) ? bw_get_product_labels_settings() : [];
+        $product_ids = bw_ss_get_trending_product_ids_for_label( $label_key, $scope, 12, $settings );
+
+        wp_send_json_success(
+            [
+                'mode'  => $mode,
+                'scope' => $scope,
+                'items' => bw_ss_build_overlay_suggestions( $product_ids ),
+            ]
+        );
+    }
+
+    // ── Fallback ──────────────────────────────────────────────────────────────
+    $settings    = function_exists( 'bw_get_product_labels_settings' ) ? bw_get_product_labels_settings() : [];
+    $product_ids = bw_ss_get_trending_product_ids_for_label( 'staff_select', $scope, 12, $settings );
 
     wp_send_json_success(
         [
-            'mode'       => 'trending',
-            'scope'      => $scope,
-            'search_url' => bw_ss_build_search_results_navigation_url( '', $scope ),
-            'rows'       => bw_ss_get_trending_rows( $scope ),
+            'mode'  => 'trending',
+            'scope' => $scope,
+            'items' => bw_ss_build_overlay_suggestions( $product_ids ),
         ]
     );
 }

--- a/includes/modules/search-surface/frontend/search-surface-template.php
+++ b/includes/modules/search-surface/frontend/search-surface-template.php
@@ -94,13 +94,27 @@ function bw_ss_enqueue_frontend_assets() {
             'sidebarGroups'    => bw_ss_get_overlay_sidebar_groups_map(),
             'groupIcons'       => bw_ss_get_group_icon_map(),
             'strings'          => [
-                'searchActionLabel' => __( 'Search for', 'bw-elementor-widgets' ),
-                'searchActionHint'  => __( 'Enter', 'bw-elementor-widgets' ),
-                'browsePlaceholder' => __( 'Facet browsing will be expanded in the next milestone.', 'bw-elementor-widgets' ),
-                'emptyBrowse'       => __( 'No values are available for this filter.', 'bw-elementor-widgets' ),
-                'emptySuggestions'  => __( 'No matching products found.', 'bw-elementor-widgets' ),
-                'emptyTrending'     => __( 'No curated products are available right now.', 'bw-elementor-widgets' ),
-                'loading'           => __( 'Loading…', 'bw-elementor-widgets' ),
+                'searchActionLabel'   => __( 'Search for', 'bw-elementor-widgets' ),
+                'searchActionHint'    => __( 'Enter', 'bw-elementor-widgets' ),
+                'emptyBrowse'         => __( 'No values are available for this filter.', 'bw-elementor-widgets' ),
+                'emptySuggestions'    => __( 'No matching products found.', 'bw-elementor-widgets' ),
+                'emptyFeed'           => __( 'No products available right now.', 'bw-elementor-widgets' ),
+                'loading'             => __( 'Loading…', 'bw-elementor-widgets' ),
+                'seeAllResults'       => __( 'See all results', 'bw-elementor-widgets' ),
+                'modeLabelTrending'   => __( 'Trending', 'bw-elementor-widgets' ),
+                'modeLabelNew'        => __( 'New Arrivals', 'bw-elementor-widgets' ),
+                'modeLabelSale'       => __( 'On Sale', 'bw-elementor-widgets' ),
+                'modeLabelFree'       => __( 'Free Downloads', 'bw-elementor-widgets' ),
+                'filterGroupCategories' => __( 'Categories', 'bw-elementor-widgets' ),
+                'filterGroupTags'       => __( 'Style / Subject', 'bw-elementor-widgets' ),
+                'filterGroupYear'       => __( 'Year', 'bw-elementor-widgets' ),
+                'filterYearFrom'        => __( 'From', 'bw-elementor-widgets' ),
+                'filterYearTo'          => __( 'To', 'bw-elementor-widgets' ),
+                'filterYearAny'         => __( 'Any year', 'bw-elementor-widgets' ),
+                'filterResultCount'     => __( '%d results', 'bw-elementor-widgets' ),
+                'filterReset'           => __( 'Reset', 'bw-elementor-widgets' ),
+                'filterShowResults'     => __( 'Show results', 'bw-elementor-widgets' ),
+                'filterEmpty'           => __( 'No filters available for this scope.', 'bw-elementor-widgets' ),
             ],
         ]
     );
@@ -202,6 +216,15 @@ function bw_ss_render_search_surface_template( $overlay_args = [] ) {
                     <div class="bw-search-surface__content-header" data-bw-search-content-header hidden></div>
                     <div class="bw-search-surface__content" data-bw-search-content aria-live="polite">
                         <div class="bw-search-surface__empty"><?php esc_html_e( 'Loading…', 'bw-elementor-widgets' ); ?></div>
+                    </div>
+                    <div class="bw-search-surface__filter-footer" data-bw-filter-footer hidden>
+                        <div class="bw-search-surface__filter-footer-inner">
+                            <div class="bw-search-surface__filter-meta">
+                                <span class="bw-search-surface__filter-count" data-bw-filter-count></span>
+                                <button class="bw-search-surface__filter-reset" type="button" data-bw-filter-reset><?php esc_html_e( 'Reset', 'bw-elementor-widgets' ); ?></button>
+                            </div>
+                            <button class="bw-search-surface__filter-apply" type="button" data-bw-filter-apply><?php esc_html_e( 'Show results', 'bw-elementor-widgets' ); ?></button>
+                        </div>
                     </div>
                 </section>
             </div>

--- a/includes/modules/search-surface/frontend/search-surface.css
+++ b/includes/modules/search-surface/frontend/search-surface.css
@@ -1051,3 +1051,420 @@ body.bw-search-overlay-active {
         display: none;
     }
 }
+
+/* ─── Feed grid (trending / new / sale / free modes) ─────────────────────── */
+
+.bw-search-surface__feed-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px;
+    padding: 4px 0;
+}
+
+.bw-search-surface__feed-card {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    text-decoration: none;
+    color: inherit;
+    border-radius: 14px;
+    overflow: hidden;
+    background: var(--bw-search-surface-card-bg);
+    border: 1px solid var(--bw-search-surface-card-border);
+    transition: background 0.15s;
+}
+
+.bw-search-surface__feed-card:hover {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.bw-search-surface__feed-image {
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.06);
+    flex-shrink: 0;
+}
+
+.bw-search-surface__feed-image--empty {
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.bw-search-surface__feed-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.bw-search-surface__feed-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 0 10px 10px;
+}
+
+.bw-search-surface__feed-title {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--bw-search-surface-text);
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.bw-search-surface__feed-price {
+    font-size: 0.75rem;
+    color: var(--bw-search-surface-text-muted);
+}
+
+.bw-search-surface__feed-price .woocommerce-Price-amount {
+    color: var(--bw-search-surface-text-muted);
+}
+
+/* "See all results" footer link (suggest has_more) */
+.bw-search-surface__see-all {
+    display: block;
+    padding: 10px 16px;
+    text-align: center;
+    font-size: 0.82rem;
+    font-weight: 500;
+    color: var(--bw-search-surface-text-muted);
+    text-decoration: none;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+    margin-top: 4px;
+    transition: color 0.15s;
+}
+
+.bw-search-surface__see-all:hover {
+    color: var(--bw-search-surface-text);
+}
+
+/* ─── Filter panel ───────────────────────────────────────────────────────── */
+
+.bw-search-surface__filter-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+}
+
+/* Chips */
+.bw-search-surface__filter-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 0 0 12px;
+}
+
+.bw-search-surface__filter-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 6px 4px 10px;
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    font-size: 0.77rem;
+    color: var(--bw-search-surface-text);
+    line-height: 1;
+}
+
+.bw-search-surface__filter-chip-label {
+    white-space: nowrap;
+}
+
+.bw-search-surface__filter-chip-remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: var(--bw-search-surface-text-muted);
+    border-radius: 50%;
+    flex-shrink: 0;
+    transition: background 0.15s, color 0.15s;
+}
+
+.bw-search-surface__filter-chip-remove:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--bw-search-surface-text);
+}
+
+.bw-search-surface__filter-chip-remove svg {
+    width: 10px;
+    height: 10px;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+}
+
+/* Accordion group */
+.bw-search-surface__filter-group {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.bw-search-surface__filter-group-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: 12px 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: var(--bw-search-surface-text);
+    text-align: left;
+    gap: 8px;
+}
+
+.bw-search-surface__filter-group-label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    flex: 1;
+}
+
+.bw-search-surface__filter-group-chevron {
+    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
+    color: var(--bw-search-surface-text-muted);
+    transition: transform 0.2s;
+}
+
+.bw-search-surface__filter-group-chevron svg {
+    width: 16px;
+    height: 16px;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    fill: none;
+}
+
+.bw-search-surface__filter-group.is-open .bw-search-surface__filter-group-chevron {
+    transform: rotate(180deg);
+}
+
+.bw-search-surface__filter-group-panel {
+    padding-bottom: 10px;
+}
+
+/* Options (checkboxes) */
+.bw-search-surface__filter-options {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.bw-search-surface__filter-option {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 6px 8px;
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: var(--bw-search-surface-text-muted);
+    text-align: left;
+    border-radius: 8px;
+    font-size: 0.83rem;
+    transition: background 0.12s, color 0.12s;
+}
+
+.bw-search-surface__filter-option:hover {
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--bw-search-surface-text);
+}
+
+.bw-search-surface__filter-option.is-selected {
+    color: var(--bw-search-surface-text);
+}
+
+.bw-search-surface__filter-option-check {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    border-radius: 4px;
+    border: 1.5px solid rgba(255, 255, 255, 0.3);
+    background: none;
+    flex-shrink: 0;
+    transition: border-color 0.12s, background 0.12s;
+}
+
+.bw-search-surface__filter-option.is-selected .bw-search-surface__filter-option-check {
+    background: #fff;
+    border-color: #fff;
+}
+
+.bw-search-surface__filter-option-tick {
+    width: 10px;
+    height: 10px;
+    stroke: #111;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    fill: none;
+    opacity: 0;
+    transition: opacity 0.12s;
+}
+
+.bw-search-surface__filter-option.is-selected .bw-search-surface__filter-option-tick {
+    opacity: 1;
+}
+
+.bw-search-surface__filter-option-label {
+    flex: 1;
+    line-height: 1.25;
+}
+
+.bw-search-surface__filter-option-count {
+    font-size: 0.75em;
+    color: var(--bw-search-surface-text-soft);
+    margin-left: 2px;
+}
+
+/* Year range */
+.bw-search-surface__year-fields {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 0 8px;
+}
+
+.bw-search-surface__year-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
+}
+
+.bw-search-surface__year-field-label {
+    font-size: 0.72rem;
+    color: var(--bw-search-surface-text-muted);
+    font-weight: 500;
+}
+
+.bw-search-surface__year-input {
+    width: 100%;
+    padding: 7px 10px;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--bw-search-surface-text);
+    font-size: 0.85rem;
+    appearance: textfield;
+    -moz-appearance: textfield;
+}
+
+.bw-search-surface__year-input::-webkit-outer-spin-button,
+.bw-search-surface__year-input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+.bw-search-surface__year-input:focus {
+    outline: none;
+    border-color: rgba(255, 255, 255, 0.3);
+}
+
+.bw-search-surface__year-sep {
+    font-size: 1rem;
+    color: var(--bw-search-surface-text-muted);
+    align-self: flex-end;
+    padding-bottom: 8px;
+    flex-shrink: 0;
+}
+
+/* Filter footer */
+.bw-search-surface__filter-footer {
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 12px 20px;
+    background: var(--bw-search-surface-panel-bg);
+}
+
+.bw-search-surface__filter-footer-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.bw-search-surface__filter-meta {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.bw-search-surface__filter-count {
+    font-size: 0.8rem;
+    color: var(--bw-search-surface-text-muted);
+    font-weight: 500;
+}
+
+.bw-search-surface__filter-reset {
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: var(--bw-search-surface-text-muted);
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    transition: color 0.15s;
+}
+
+.bw-search-surface__filter-reset:hover {
+    color: var(--bw-search-surface-text);
+}
+
+.bw-search-surface__filter-apply {
+    padding: 9px 20px;
+    border-radius: 10px;
+    border: none;
+    background: #22c55e;
+    color: #fff;
+    font-size: 0.84rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s;
+    white-space: nowrap;
+}
+
+.bw-search-surface__filter-apply:hover {
+    background: #16a34a;
+}
+
+/* ─── Responsive overrides ───────────────────────────────────────────────── */
+
+@media (max-width: 900px) {
+    .bw-search-surface__feed-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 520px) {
+    .bw-search-surface__feed-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 8px;
+    }
+
+    .bw-search-surface__filter-footer {
+        padding: 10px 14px;
+    }
+
+    .bw-search-surface__year-fields {
+        flex-wrap: wrap;
+    }
+
+    .bw-search-surface__year-sep {
+        display: none;
+    }
+}

--- a/includes/modules/search-surface/frontend/search-surface.js
+++ b/includes/modules/search-surface/frontend/search-surface.js
@@ -101,7 +101,7 @@
             return;
         }
 
-        requestTrending(surfaceState);
+        requestMode(surfaceState, surfaceState.mode);
     }
 
     function openSurfaceDialog(surfaceState) {
@@ -113,16 +113,12 @@
         document.body.classList.add('bw-search-overlay-active');
         openSurface = surfaceState;
 
-        if (!surfaceState.query && surfaceState.hasLoadedTrending) {
-            renderTrending(surfaceState, surfaceState.trendingRows || []);
-        }
-
         window.setTimeout(function () {
             surfaceState.input.focus();
         }, 40);
 
-        if (!surfaceState.hasLoadedTrending) {
-            requestTrending(surfaceState);
+        if (!surfaceState.query) {
+            requestMode(surfaceState, surfaceState.mode);
         }
     }
 
@@ -130,6 +126,12 @@
         if (surfaceState.abortController) {
             surfaceState.abortController.abort();
             surfaceState.abortController = null;
+        }
+
+        window.clearTimeout(surfaceState.filterCountTimer);
+        if (surfaceState.filterCountAbortController) {
+            surfaceState.filterCountAbortController.abort();
+            surfaceState.filterCountAbortController = null;
         }
 
         window.clearTimeout(surfaceState.debounceTimer);
@@ -140,7 +142,11 @@
         }
         surfaceState.query = '';
         surfaceState.activeGroup = 'trending';
+        surfaceState.mode = 'trending';
         surfaceState.input.value = '';
+
+        if (surfaceState.filterFooter) { surfaceState.filterFooter.hidden = true; }
+
         syncLayoutMode(surfaceState);
         document.body.classList.remove('bw-search-overlay-active');
 
@@ -211,6 +217,327 @@
         surfaceState.content.innerHTML = '<div class="bw-search-surface__rows">' + html + '</div>';
     }
 
+    function renderFeed(surfaceState, mode, payload) {
+        var items = (payload && Array.isArray(payload.items)) ? payload.items : [];
+        var modeLabels = {
+            trending: strings.modeLabelTrending || 'Trending',
+            new:      strings.modeLabelNew      || 'New Arrivals',
+            sale:     strings.modeLabelSale     || 'On Sale',
+            free:     strings.modeLabelFree     || 'Free Downloads'
+        };
+
+        surfaceState.mode = mode;
+        surfaceState.activeGroup = mode;
+        syncLayoutMode(surfaceState);
+        renderSidebar(surfaceState);
+        setContentHeader(surfaceState, modeLabels[mode] || mode);
+
+        if (surfaceState.filterFooter) {
+            surfaceState.filterFooter.hidden = true;
+        }
+
+        if (!items.length) {
+            surfaceState.content.innerHTML =
+                '<div class="bw-search-surface__empty">' +
+                escapeHtml(strings.emptyFeed || 'No products available right now.') +
+                '</div>';
+            return;
+        }
+
+        var html = items.map(function (item) {
+            var imageHtml = item.image_url
+                ? '<div class="bw-search-surface__feed-image"><img src="' + escapeHtml(item.image_url) +
+                  '" alt="' + escapeHtml(item.title) + '" loading="lazy"></div>'
+                : '<div class="bw-search-surface__feed-image bw-search-surface__feed-image--empty"></div>';
+
+            var priceHtml = item.price_html
+                ? '<span class="bw-search-surface__feed-price">' + item.price_html + '</span>'
+                : '';
+
+            return (
+                '<a class="bw-search-surface__feed-card" href="' + escapeHtml(item.permalink) + '">' +
+                    imageHtml +
+                    '<div class="bw-search-surface__feed-copy">' +
+                        '<span class="bw-search-surface__feed-title">' + escapeHtml(item.title) + '</span>' +
+                        priceHtml +
+                    '</div>' +
+                '</a>'
+            );
+        }).join('');
+
+        surfaceState.content.innerHTML = '<div class="bw-search-surface__feed-grid">' + html + '</div>';
+    }
+
+    // ─── Filter helpers ──────────────────────────────────────────────────────
+
+    function toggleInArray(arr, val) {
+        var idx = arr.indexOf(val);
+        if (idx !== -1) { arr.splice(idx, 1); } else { arr.push(val); }
+    }
+
+    function findInItems(items, id) {
+        var strId = String(id);
+        for (var i = 0; i < items.length; i++) {
+            var itemId = String(items[i].id || items[i].term_id || '');
+            if (itemId === strId) { return items[i]; }
+            if (Array.isArray(items[i].children)) {
+                var found = findInItems(items[i].children, id);
+                if (found) { return found; }
+            }
+        }
+        return null;
+    }
+
+    function getOpenFilterGroups(surfaceState) {
+        var open = [];
+        if (!surfaceState.content) { return open; }
+        Array.prototype.forEach.call(surfaceState.content.querySelectorAll('[data-bw-filter-group]'), function (group) {
+            if (group.classList.contains('is-open')) { open.push(group.getAttribute('data-bw-filter-group')); }
+        });
+        return open;
+    }
+
+    function restoreOpenFilterGroups(surfaceState, openGroups) {
+        if (!openGroups || !openGroups.length || !surfaceState.content) { return; }
+        Array.prototype.forEach.call(surfaceState.content.querySelectorAll('[data-bw-filter-group]'), function (group) {
+            if (openGroups.indexOf(group.getAttribute('data-bw-filter-group')) !== -1) {
+                group.classList.add('is-open');
+                var panel = group.querySelector('.bw-search-surface__filter-group-panel');
+                if (panel) { panel.hidden = false; }
+            }
+        });
+    }
+
+    function updateFilterCount(surfaceState, count) {
+        if (!surfaceState.filterCount) { return; }
+        var template = strings.filterResultCount || '%d results';
+        surfaceState.filterCount.textContent = template.replace('%d', String(count !== undefined ? count : 0));
+    }
+
+    function scheduleFilterCount(surfaceState) {
+        window.clearTimeout(surfaceState.filterCountTimer);
+        surfaceState.filterCountTimer = window.setTimeout(function () {
+            if (surfaceState.filterCountAbortController) { surfaceState.filterCountAbortController.abort(); }
+            surfaceState.filterCountAbortController = new AbortController();
+
+            var sel = surfaceState.filterSel;
+            var postParams = new URLSearchParams();
+            postParams.set('action', 'bw_ss_overlay_payload');
+            postParams.set('nonce', config.nonce || '');
+            postParams.set('mode', 'filter_count');
+            postParams.set('scope', surfaceState.scope);
+            if (sel.subcategories && sel.subcategories.length) { postParams.set('subcategories', sel.subcategories.join(',')); }
+            if (sel.tags && sel.tags.length)                   { postParams.set('tags', sel.tags.join(',')); }
+            if (sel.year && sel.year.from)                     { postParams.set('year_from', sel.year.from); }
+            if (sel.year && sel.year.to)                       { postParams.set('year_to', sel.year.to); }
+            if (sel.advanced) {
+                Object.keys(sel.advanced).forEach(function (k) {
+                    if (sel.advanced[k] && sel.advanced[k].length) { postParams.set(k, sel.advanced[k].join(',')); }
+                });
+            }
+
+            window.fetch(config.ajaxUrl, {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+                body: postParams.toString(),
+                signal: surfaceState.filterCountAbortController.signal
+            }).then(function (r) { return r.json(); }).then(function (data) {
+                if (data && data.success && data.data) { updateFilterCount(surfaceState, data.data.count); }
+            }).catch(function () {});
+        }, 300);
+    }
+
+    function buildFilterNavUrl(surfaceState) {
+        var baseUrl = typeof config.searchResultsUrl === 'string' && config.searchResultsUrl ? config.searchResultsUrl : '/search/';
+        var url = new URL(baseUrl, window.location.origin);
+        var sel = surfaceState.filterSel;
+
+        url.searchParams.set('scope', surfaceState.scope || 'all');
+        (sel.subcategories || []).forEach(function (id) { url.searchParams.append('subcategories[]', id); });
+        (sel.tags || []).forEach(function (id) { url.searchParams.append('tag[]', id); });
+        if (sel.year && sel.year.from) { url.searchParams.set('year_from', sel.year.from); }
+        if (sel.year && sel.year.to)   { url.searchParams.set('year_to', sel.year.to); }
+        if (sel.advanced) {
+            Object.keys(sel.advanced).forEach(function (k) {
+                if (sel.advanced[k] && sel.advanced[k].length) { url.searchParams.set(k, sel.advanced[k].join(',')); }
+            });
+        }
+        return url.toString();
+    }
+
+    function renderFilterChipsHtml(surfaceState) {
+        var sel      = surfaceState.filterSel;
+        var filterUi = (surfaceState.filterData && surfaceState.filterData.filter_ui) ? surfaceState.filterData.filter_ui : {};
+        var types    = Array.isArray(filterUi.types) ? filterUi.types : [];
+        var tags     = Array.isArray(filterUi.tags)  ? filterUi.tags  : [];
+        var chips    = [];
+        var closeIcon = '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>';
+
+        (sel.subcategories || []).forEach(function (id) {
+            var item = findInItems(types, id);
+            chips.push({ type: 'subcategory', id: id, label: item ? (item.label || item.name || String(id)) : String(id) });
+        });
+        (sel.tags || []).forEach(function (id) {
+            var item = findInItems(tags, id);
+            chips.push({ type: 'tag', id: id, label: item ? (item.label || item.name || String(id)) : String(id) });
+        });
+        if (sel.year && (sel.year.from || sel.year.to)) {
+            var yFrom = sel.year.from ? String(sel.year.from) : (strings.filterYearAny || 'Any');
+            var yTo   = sel.year.to   ? String(sel.year.to)   : (strings.filterYearAny || 'Any');
+            chips.push({ type: 'year', label: yFrom + '–' + yTo });
+        }
+        if (sel.advanced) {
+            Object.keys(sel.advanced).forEach(function (key) {
+                (sel.advanced[key] || []).forEach(function (slug) {
+                    chips.push({ type: 'advanced', key: key, slug: slug, label: slug });
+                });
+            });
+        }
+
+        if (!chips.length) { return ''; }
+
+        var html = '<div class="bw-search-surface__filter-chips">';
+        chips.forEach(function (chip) {
+            var attrs = '';
+            if (chip.type === 'subcategory') {
+                attrs = 'data-bw-chip-type="subcategory" data-bw-chip-id="' + escapeHtml(String(chip.id)) + '"';
+            } else if (chip.type === 'tag') {
+                attrs = 'data-bw-chip-type="tag" data-bw-chip-id="' + escapeHtml(String(chip.id)) + '"';
+            } else if (chip.type === 'year') {
+                attrs = 'data-bw-chip-type="year"';
+            } else {
+                attrs = 'data-bw-chip-type="advanced" data-bw-chip-key="' + escapeHtml(chip.key) + '" data-bw-chip-slug="' + escapeHtml(chip.slug) + '"';
+            }
+            html +=
+                '<span class="bw-search-surface__filter-chip">' +
+                    '<span class="bw-search-surface__filter-chip-label">' + escapeHtml(chip.label) + '</span>' +
+                    '<button type="button" class="bw-search-surface__filter-chip-remove" aria-label="Remove filter" ' + attrs + '>' + closeIcon + '</button>' +
+                '</span>';
+        });
+        html += '</div>';
+        return html;
+    }
+
+    function renderFilterGroupHtml(groupType, label, items, selectedList, idField) {
+        var selStrs   = (selectedList || []).map(function (v) { return String(v); });
+        var chevron   = '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>';
+        var tick      = '<svg class="bw-search-surface__filter-option-tick" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M3 8l3.5 3.5L13 4"/></svg>';
+
+        var optionsHtml = items.map(function (item) {
+            var rawId    = idField ? (item[idField] !== undefined ? item[idField] : (item.id || item.term_id || item.slug || '')) : (item.id || item.term_id || item.slug || '');
+            var itemId   = String(rawId);
+            var isSelected = selStrs.indexOf(itemId) !== -1;
+            var itemLabel  = item.label || item.name || itemId;
+            var count      = item.count !== undefined && item.count !== null
+                ? ' <span class="bw-search-surface__filter-option-count">' + escapeHtml(String(item.count)) + '</span>'
+                : '';
+            return (
+                '<button type="button" class="bw-search-surface__filter-option' + (isSelected ? ' is-selected' : '') + '" ' +
+                    'data-bw-filter-option="' + escapeHtml(groupType) + '" data-bw-option-id="' + escapeHtml(itemId) + '">' +
+                    '<span class="bw-search-surface__filter-option-check" aria-hidden="true">' + tick + '</span>' +
+                    '<span class="bw-search-surface__filter-option-label">' + escapeHtml(itemLabel) + count + '</span>' +
+                '</button>'
+            );
+        }).join('');
+
+        return (
+            '<div class="bw-search-surface__filter-group" data-bw-filter-group="' + escapeHtml(groupType) + '">' +
+                '<button type="button" class="bw-search-surface__filter-group-toggle" data-bw-filter-toggle>' +
+                    '<span class="bw-search-surface__filter-group-label">' + escapeHtml(label) + '</span>' +
+                    '<span class="bw-search-surface__filter-group-chevron" aria-hidden="true">' + chevron + '</span>' +
+                '</button>' +
+                '<div class="bw-search-surface__filter-group-panel" hidden>' +
+                    '<div class="bw-search-surface__filter-options">' + optionsHtml + '</div>' +
+                '</div>' +
+            '</div>'
+        );
+    }
+
+    function renderFilterYearHtml(year, yearSel) {
+        var min     = parseInt(year.min, 10)  || 1900;
+        var max     = parseInt(year.max, 10)  || new Date().getFullYear();
+        var fromVal = yearSel && yearSel.from ? String(yearSel.from) : '';
+        var toVal   = yearSel && yearSel.to   ? String(yearSel.to)   : '';
+        var chevron = '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>';
+
+        return (
+            '<div class="bw-search-surface__filter-group" data-bw-filter-group="year">' +
+                '<button type="button" class="bw-search-surface__filter-group-toggle" data-bw-filter-toggle>' +
+                    '<span class="bw-search-surface__filter-group-label">' + escapeHtml(strings.filterGroupYear || 'Year') + '</span>' +
+                    '<span class="bw-search-surface__filter-group-chevron" aria-hidden="true">' + chevron + '</span>' +
+                '</button>' +
+                '<div class="bw-search-surface__filter-group-panel" hidden>' +
+                    '<div class="bw-search-surface__year-fields">' +
+                        '<label class="bw-search-surface__year-field">' +
+                            '<span class="bw-search-surface__year-field-label">' + escapeHtml(strings.filterYearFrom || 'From') + '</span>' +
+                            '<input type="number" class="bw-search-surface__year-input" data-bw-year-from' +
+                                ' min="' + min + '" max="' + max + '" value="' + escapeHtml(fromVal) + '" placeholder="' + min + '">' +
+                        '</label>' +
+                        '<span class="bw-search-surface__year-sep" aria-hidden="true">–</span>' +
+                        '<label class="bw-search-surface__year-field">' +
+                            '<span class="bw-search-surface__year-field-label">' + escapeHtml(strings.filterYearTo || 'To') + '</span>' +
+                            '<input type="number" class="bw-search-surface__year-input" data-bw-year-to' +
+                                ' min="' + min + '" max="' + max + '" value="' + escapeHtml(toVal) + '" placeholder="' + max + '">' +
+                        '</label>' +
+                    '</div>' +
+                '</div>' +
+            '</div>'
+        );
+    }
+
+    function renderFilter(surfaceState, payload) {
+        var openGroups = getOpenFilterGroups(surfaceState);
+
+        surfaceState.mode = 'filter';
+        surfaceState.activeGroup = 'filter';
+        surfaceState.filterData = payload || {};
+        syncLayoutMode(surfaceState);
+        renderSidebar(surfaceState);
+        setContentHeader(surfaceState, '');
+
+        if (surfaceState.filterFooter) { surfaceState.filterFooter.hidden = false; }
+
+        var filterUi = (payload && payload.filter_ui) ? payload.filter_ui : {};
+        var types    = Array.isArray(filterUi.types) ? filterUi.types : [];
+        var tags     = Array.isArray(filterUi.tags)  ? filterUi.tags  : [];
+        var year     = (filterUi.year && filterUi.year.supported) ? filterUi.year : null;
+        var advanced = (filterUi.advanced && typeof filterUi.advanced === 'object') ? filterUi.advanced : {};
+        var advKeys  = Object.keys(advanced).filter(function (k) { return Array.isArray(advanced[k]) && advanced[k].length; });
+
+        var initialCount = filterUi.result_count !== undefined ? filterUi.result_count : (payload && payload.result_count !== undefined ? payload.result_count : 0);
+        updateFilterCount(surfaceState, initialCount);
+
+        if (!types.length && !tags.length && !year && !advKeys.length) {
+            surfaceState.content.innerHTML =
+                '<div class="bw-search-surface__empty">' +
+                escapeHtml(strings.filterEmpty || 'No filters available for this scope.') +
+                '</div>';
+            return;
+        }
+
+        var html = renderFilterChipsHtml(surfaceState);
+        html += '<div class="bw-search-surface__filter-panel">';
+
+        if (types.length) {
+            html += renderFilterGroupHtml('subcategory', strings.filterGroupCategories || 'Categories', types, surfaceState.filterSel.subcategories, 'id');
+        }
+        if (tags.length) {
+            html += renderFilterGroupHtml('tag', strings.filterGroupTags || 'Style / Subject', tags, surfaceState.filterSel.tags, 'id');
+        }
+        if (year) {
+            html += renderFilterYearHtml(year, surfaceState.filterSel.year);
+        }
+        advKeys.forEach(function (key) {
+            var advLabel = key.charAt(0).toUpperCase() + key.slice(1);
+            html += renderFilterGroupHtml('advanced_' + key, advLabel, advanced[key], (surfaceState.filterSel.advanced || {})[key] || [], 'slug');
+        });
+
+        html += '</div>';
+        surfaceState.content.innerHTML = html;
+        restoreOpenFilterGroups(surfaceState, openGroups);
+    }
+
     function renderSuggest(surfaceState, payload) {
         var items = payload.items || [];
         var query = surfaceState.query;
@@ -251,12 +578,18 @@
                         '<span class="bw-search-surface__row-title-text">' + escapeHtml(item.title) + '</span>' +
                         '<span class="bw-search-surface__row-meta">' + escapeHtml(item.description || '') + '</span>' +
                     '</span>' +
-                    '<span class="bw-search-surface__row-action"></span>' +
                 '</a>'
             );
         }).join('');
 
-        surfaceState.content.innerHTML = '<div class="bw-search-surface__row-group">' + actionRow + suggestRows + '</div>';
+        var hasMoreFooter = payload.has_more
+            ? '<a class="bw-search-surface__see-all" href="' + escapeHtml(searchUrl) + '">' +
+              escapeHtml(strings.seeAllResults || 'See all results') + '</a>'
+            : '';
+
+        surfaceState.content.innerHTML =
+            '<div class="bw-search-surface__row-group">' + actionRow + suggestRows + '</div>' +
+            hasMoreFooter;
     }
 
     function renderBrowse(surfaceState, groupKey, payload) {
@@ -315,6 +648,39 @@
             }
 
             renderBrowse(surfaceState, groupKey, { items: [] });
+        });
+    }
+
+    function requestMode(surfaceState, mode) {
+        mode = (typeof mode === 'string' && mode) ? mode : 'trending';
+        setLoadingState(surfaceState);
+
+        requestPayload(surfaceState, mode, {}).then(function (response) {
+            if (!response || !response.success || !response.data) {
+                if ('filter' === mode) {
+                    renderFilter(surfaceState, {});
+                } else {
+                    renderFeed(surfaceState, mode, { items: [] });
+                }
+
+                return;
+            }
+
+            if ('filter' === mode) {
+                renderFilter(surfaceState, response.data);
+            } else {
+                renderFeed(surfaceState, mode, response.data);
+            }
+        }).catch(function (error) {
+            if (error && error.name === 'AbortError') {
+                return;
+            }
+
+            if ('filter' === mode) {
+                renderFilter(surfaceState, {});
+            } else {
+                renderFeed(surfaceState, mode, { items: [] });
+            }
         });
     }
 
@@ -394,7 +760,7 @@
         window.clearTimeout(surfaceState.debounceTimer);
 
         if (!surfaceState.query) {
-            requestTrending(surfaceState);
+            requestMode(surfaceState, surfaceState.mode);
             return;
         }
 
@@ -436,6 +802,10 @@
             sidebar: surface.querySelector('[data-bw-search-sidebar]'),
             content: surface.querySelector('[data-bw-search-content]'),
             contentHeader: surface.querySelector('[data-bw-search-content-header]'),
+            filterFooter: surface.querySelector('[data-bw-filter-footer]'),
+            filterCount: surface.querySelector('[data-bw-filter-count]'),
+            filterApply: surface.querySelector('[data-bw-filter-apply]'),
+            filterReset: surface.querySelector('[data-bw-filter-reset]'),
             scopeInput: surface.querySelector('[data-bw-search-scope-input]'),
             scopeTrigger: surface.querySelector('[data-bw-scope-toggle]'),
             scopeRoot: surface.querySelector('[data-bw-search-scope]'),
@@ -445,10 +815,12 @@
             activeGroup: 'trending',
             query: '',
             mode: 'trending',
+            filterData: null,
+            filterSel: { subcategories: [], tags: [], year: { from: null, to: null }, advanced: {} },
+            filterCountTimer: null,
+            filterCountAbortController: null,
             debounceTimer: null,
-            abortController: null,
-            hasLoadedTrending: false,
-            trendingRows: []
+            abortController: null
         };
 
         renderSidebar(surfaceState);
@@ -480,15 +852,99 @@
                 return;
             }
 
-            if (groupButton.getAttribute('data-bw-search-group') === 'trending') {
-                surfaceState.query = '';
-                surfaceState.input.value = '';
-                requestTrending(surfaceState);
+            var clickedMode = groupButton.getAttribute('data-bw-search-group');
+            surfaceState.mode = clickedMode;
+            requestMode(surfaceState, clickedMode);
+        });
+
+        surfaceState.content.addEventListener('click', function (event) {
+            if (surfaceState.mode !== 'filter') { return; }
+
+            var toggleBtn = event.target.closest('[data-bw-filter-toggle]');
+            if (toggleBtn) {
+                var group = toggleBtn.closest('[data-bw-filter-group]');
+                if (group) {
+                    var panel = group.querySelector('.bw-search-surface__filter-group-panel');
+                    var isOpen = group.classList.contains('is-open');
+                    group.classList.toggle('is-open', !isOpen);
+                    if (panel) { panel.hidden = isOpen; }
+                }
                 return;
             }
 
-            requestBrowse(surfaceState, groupButton.getAttribute('data-bw-search-group'));
+            var chipRemove = event.target.closest('[data-bw-chip-type]');
+            if (chipRemove) {
+                var chipType = chipRemove.getAttribute('data-bw-chip-type');
+                var chipId   = chipRemove.getAttribute('data-bw-chip-id');
+                var chipKey  = chipRemove.getAttribute('data-bw-chip-key');
+                var chipSlug = chipRemove.getAttribute('data-bw-chip-slug');
+                var cSel = surfaceState.filterSel;
+
+                if (chipType === 'subcategory' && chipId) {
+                    cSel.subcategories = cSel.subcategories.filter(function (v) { return String(v) !== chipId; });
+                } else if (chipType === 'tag' && chipId) {
+                    cSel.tags = cSel.tags.filter(function (v) { return String(v) !== chipId; });
+                } else if (chipType === 'year') {
+                    cSel.year = { from: null, to: null };
+                } else if (chipType === 'advanced' && chipKey && chipSlug) {
+                    if (cSel.advanced[chipKey]) {
+                        cSel.advanced[chipKey] = cSel.advanced[chipKey].filter(function (s) { return s !== chipSlug; });
+                    }
+                }
+
+                renderFilter(surfaceState, surfaceState.filterData);
+                scheduleFilterCount(surfaceState);
+                return;
+            }
+
+            var optionBtn = event.target.closest('[data-bw-filter-option]');
+            if (optionBtn) {
+                var optionType = optionBtn.getAttribute('data-bw-filter-option');
+                var optionId   = optionBtn.getAttribute('data-bw-option-id');
+                var oSel = surfaceState.filterSel;
+
+                if (optionType === 'subcategory') {
+                    toggleInArray(oSel.subcategories, optionId);
+                } else if (optionType === 'tag') {
+                    toggleInArray(oSel.tags, optionId);
+                } else if (optionType && optionType.indexOf('advanced_') === 0) {
+                    var advKey = optionType.slice(9);
+                    if (!oSel.advanced[advKey]) { oSel.advanced[advKey] = []; }
+                    toggleInArray(oSel.advanced[advKey], optionId);
+                }
+
+                renderFilter(surfaceState, surfaceState.filterData);
+                scheduleFilterCount(surfaceState);
+                return;
+            }
         });
+
+        surfaceState.content.addEventListener('input', function (event) {
+            if (surfaceState.mode !== 'filter') { return; }
+            if (event.target.hasAttribute('data-bw-year-from') || event.target.hasAttribute('data-bw-year-to')) {
+                var fromEl  = surfaceState.content.querySelector('[data-bw-year-from]');
+                var toEl    = surfaceState.content.querySelector('[data-bw-year-to]');
+                var fromVal = fromEl && fromEl.value ? (parseInt(fromEl.value, 10) || null) : null;
+                var toVal   = toEl && toEl.value ? (parseInt(toEl.value, 10) || null) : null;
+                surfaceState.filterSel.year = { from: fromVal, to: toVal };
+                scheduleFilterCount(surfaceState);
+            }
+        });
+
+        if (surfaceState.filterApply) {
+            surfaceState.filterApply.addEventListener('click', function () {
+                window.location.href = buildFilterNavUrl(surfaceState);
+            });
+        }
+
+        if (surfaceState.filterReset) {
+            surfaceState.filterReset.addEventListener('click', function () {
+                surfaceState.filterSel = { subcategories: [], tags: [], year: { from: null, to: null }, advanced: {} };
+                renderFilter(surfaceState, surfaceState.filterData);
+                var fUi = (surfaceState.filterData && surfaceState.filterData.filter_ui) ? surfaceState.filterData.filter_ui : {};
+                updateFilterCount(surfaceState, fUi.result_count !== undefined ? fUi.result_count : 0);
+            });
+        }
 
         surfaceState.scopeRoot.addEventListener('click', function (event) {
             var scopeButton = event.target.closest('[data-bw-scope-option]');

--- a/includes/modules/search-surface/runtime/popup-config.php
+++ b/includes/modules/search-surface/runtime/popup-config.php
@@ -4,114 +4,85 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Single source of truth for search popup group and scope metadata.
+ * Single source of truth for search popup mode and scope metadata.
  *
  * Both PHP rendering and JS (via wp_localize_script) read from these
- * definitions, eliminating the duplicated SVG switch blocks and scattered
- * hardcoded arrays that previously lived across search-surface-template.php,
- * url-state.php, and ajax-search-surface.php.
+ * definitions. The sidebar now uses five explicit modes (filter, trending,
+ * new, sale, free) instead of the old browse-group model.
  */
 
 function bw_ss_get_group_definitions() {
+    $filter_svg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M10 5H3"/><path d="M12 19H3"/><path d="M14 3v4"/><path d="M16 17v4"/><path d="M21 12h-9"/><path d="M21 19h-5"/><path d="M21 5h-7"/><path d="M8 10v4"/><path d="M8 12H3"/></svg>';
+
     $trending_svg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M16 7h6v6"/><path d="m22 7-8.5 8.5-5-5L2 17"/></svg>';
 
-    $categories_svg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M7 2h10"/><path d="M5 6h14"/><rect width="18" height="12" x="3" y="10" rx="2"/></svg>';
+    $new_svg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M12 2v4"/><path d="M12 18v4"/><path d="m4.93 4.93 2.83 2.83"/><path d="m16.24 16.24 2.83 2.83"/><path d="M2 12h4"/><path d="M18 12h4"/><path d="m4.93 19.07 2.83-2.83"/><path d="m16.24 7.76 2.83-2.83"/></svg>';
 
-    // Used by: tags, technique, source, artist
-    $tag_svg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M12 12V4a1 1 0 0 1 1-1h6.297a1 1 0 0 1 .651 1.759l-4.696 4.025"/><path d="m12 21-7.414-7.414A2 2 0 0 1 4 12.172V6.415a1.002 1.002 0 0 1 1.707-.707L20 20.009"/><path d="m12.214 3.381 8.414 14.966a1 1 0 0 1-.167 1.199l-1.168 1.163a1 1 0 0 1-.706.291H6.351a1 1 0 0 1-.625-.219L3.25 18.8a1 1 0 0 1 .631-1.781l4.165.027"/></svg>';
+    $sale_svg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M9 9h.01"/><path d="M15 15h.01"/><path d="M9.5 14.5 15 9"/><path d="m14 2-8.5 8.5c-.83.83-.83 2.17 0 3L6.8 14.8c.83.83 2.17.83 3 0L18.5 6"/><path d="M14 2h8v8"/><path d="m5 15-3 3 3 3 3-3"/></svg>';
 
-    // Used by: author, publisher
-    $book_svg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M12 7v14"/><path d="M16 12h2"/><path d="M16 8h2"/><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"/><path d="M6 12h2"/><path d="M6 8h2"/></svg>';
-
-    $years_svg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M16 14v2.2l1.6 1"/><path d="M16 2v4"/><path d="M21 7.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h3.5"/><path d="M3 10h5"/><path d="M8 2v4"/><circle cx="16" cy="16" r="6"/></svg>';
+    $free_svg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>';
 
     return [
-        'trending'   => [
-            'label'       => __( 'Trending', 'bw-elementor-widgets' ),
-            'icon_svg'    => $trending_svg,
-            'param_key'   => '',
-            'browse_type' => '',
+        'filter'   => [
+            'label'     => __( 'Filter', 'bw-elementor-widgets' ),
+            'icon_svg'  => $filter_svg,
+            'mode_type' => 'filter',
+            'param_key' => '',
         ],
-        'categories' => [
-            'label'       => __( 'Categories', 'bw-elementor-widgets' ),
-            'icon_svg'    => $categories_svg,
-            'param_key'   => 'category',
-            'browse_type' => 'category',
+        'trending' => [
+            'label'     => __( 'Trending', 'bw-elementor-widgets' ),
+            'icon_svg'  => $trending_svg,
+            'mode_type' => 'feed',
+            'param_key' => '',
         ],
-        'tags'       => [
-            'label'       => __( 'Style / Subject', 'bw-elementor-widgets' ),
-            'icon_svg'    => $tag_svg,
-            'param_key'   => 'tag',
-            'browse_type' => 'tag',
+        'new'      => [
+            'label'     => __( 'New', 'bw-elementor-widgets' ),
+            'icon_svg'  => $new_svg,
+            'mode_type' => 'feed',
+            'param_key' => '',
         ],
-        'years'      => [
-            'label'       => __( 'Year', 'bw-elementor-widgets' ),
-            'icon_svg'    => $years_svg,
-            'param_key'   => 'year',
-            'browse_type' => 'year',
+        'sale'     => [
+            'label'     => __( 'On Sale', 'bw-elementor-widgets' ),
+            'icon_svg'  => $sale_svg,
+            'mode_type' => 'feed',
+            'param_key' => '',
         ],
-        'source'     => [
-            'label'       => __( 'Sources', 'bw-elementor-widgets' ),
-            'icon_svg'    => $tag_svg,
-            'param_key'   => 'source',
-            'browse_type' => 'advanced',
-        ],
-        'technique'  => [
-            'label'       => __( 'Technique', 'bw-elementor-widgets' ),
-            'icon_svg'    => $tag_svg,
-            'param_key'   => 'technique',
-            'browse_type' => 'advanced',
-        ],
-        'author'     => [
-            'label'       => __( 'Authors', 'bw-elementor-widgets' ),
-            'icon_svg'    => $book_svg,
-            'param_key'   => 'author',
-            'browse_type' => 'advanced',
-        ],
-        'publisher'  => [
-            'label'       => __( 'Publisher', 'bw-elementor-widgets' ),
-            'icon_svg'    => $book_svg,
-            'param_key'   => 'publisher',
-            'browse_type' => 'advanced',
-        ],
-        'artist'     => [
-            'label'       => __( 'Artists', 'bw-elementor-widgets' ),
-            'icon_svg'    => $tag_svg,
-            'param_key'   => 'artist',
-            'browse_type' => 'advanced',
+        'free'     => [
+            'label'     => __( 'Free', 'bw-elementor-widgets' ),
+            'icon_svg'  => $free_svg,
+            'mode_type' => 'feed',
+            'param_key' => '',
         ],
     ];
 }
 
 function bw_ss_get_scope_definitions() {
+    $modes = [ 'filter', 'trending', 'new', 'sale', 'free' ];
+
     return [
         'all'                 => [
             'label'        => __( 'All', 'bw-elementor-widgets' ),
             'context_slug' => '',
-            'groups'       => [ 'trending', 'categories', 'tags', 'years' ],
+            'groups'       => $modes,
         ],
         'digital-collections' => [
             'label'        => __( 'Digital Collections', 'bw-elementor-widgets' ),
             'context_slug' => 'digital-collections',
-            'groups'       => [ 'trending', 'categories', 'source', 'technique', 'years' ],
+            'groups'       => $modes,
         ],
         'books'               => [
             'label'        => __( 'Books', 'bw-elementor-widgets' ),
             'context_slug' => 'books',
-            'groups'       => [ 'trending', 'categories', 'author', 'publisher', 'years' ],
+            'groups'       => $modes,
         ],
         'prints'              => [
             'label'        => __( 'Prints', 'bw-elementor-widgets' ),
             'context_slug' => 'prints',
-            'groups'       => [ 'trending', 'categories', 'artist', 'technique', 'years' ],
+            'groups'       => $modes,
         ],
     ];
 }
 
-/**
- * Returns a flat icon map keyed by group key, for use in wp_localize_script.
- * Eliminates the duplicate SVG switch block that previously lived in search-surface.js.
- */
 function bw_ss_get_group_icon_map() {
     $map = [];
 

--- a/includes/modules/search-surface/runtime/trending-source.php
+++ b/includes/modules/search-surface/runtime/trending-source.php
@@ -212,6 +212,7 @@ function bw_ss_build_overlay_product_preview( $product_id ) {
         'permalink'   => get_permalink( $product_id ),
         'image_url'   => is_string( $image_url ) ? $image_url : '',
         'description' => $description,
+        'price_html'  => function_exists( 'bw_fpw_get_price_markup' ) ? bw_fpw_get_price_markup( $product_id ) : '',
     ];
 }
 

--- a/includes/modules/search-surface/runtime/url-state.php
+++ b/includes/modules/search-surface/runtime/url-state.php
@@ -165,6 +165,8 @@ function bw_ss_sanitize_current_query_arg_value( $key, $raw_value ) {
         case 'page':
             return max( 1, absint( bw_ss_sanitize_query_arg_text_value( $raw_value ) ) );
         case 'year':
+        case 'year_from':
+        case 'year_to':
         case 'q':
         case 'category':
             return bw_ss_sanitize_query_arg_text_value( $raw_value );
@@ -357,9 +359,14 @@ function bw_ss_build_search_results_state_from_url() {
         isset( $query_args['tag'] ) ? $query_args['tag'] : ( $query_args['tags'] ?? [] ),
         'product_tag'
     );
-    $year             = function_exists( 'bw_fpw_normalize_year_bound' )
-        ? bw_fpw_normalize_year_bound( $query_args['year'] ?? null )
-        : null;
+    $year_from_raw    = $query_args['year_from'] ?? ( $query_args['year'] ?? null );
+    $year_to_raw      = $query_args['year_to'] ?? ( $query_args['year'] ?? null );
+    $year_from        = function_exists( 'bw_fpw_normalize_year_bound' )
+        ? bw_fpw_normalize_year_bound( $year_from_raw )
+        : ( ! empty( $year_from_raw ) ? absint( $year_from_raw ) : null );
+    $year_to          = function_exists( 'bw_fpw_normalize_year_bound' )
+        ? bw_fpw_normalize_year_bound( $year_to_raw )
+        : ( ! empty( $year_to_raw ) ? absint( $year_to_raw ) : null );
     $artist           = bw_ss_resolve_advanced_filter_tokens_from_query( 'artist', $query_args['artist'] ?? [], $scope );
     $author           = bw_ss_resolve_advanced_filter_tokens_from_query( 'author', $query_args['author'] ?? [], $scope );
     $publisher        = bw_ss_resolve_advanced_filter_tokens_from_query( 'publisher', $query_args['publisher'] ?? [], $scope );
@@ -391,8 +398,8 @@ function bw_ss_build_search_results_state_from_url() {
         'tags'          => isset( $tags_data['ids'] ) ? (array) $tags_data['ids'] : [],
         'tag_terms'     => isset( $tags_data['terms'] ) ? (array) $tags_data['terms'] : [],
         'year'          => [
-            'from' => $year,
-            'to'   => $year,
+            'from' => $year_from,
+            'to'   => $year_to,
         ],
         'advanced'      => [
             'artist'    => $artist,
@@ -463,6 +470,27 @@ function bw_ss_build_search_results_query_args( $query = '', $scope = 'all', $fi
 
         if ( ! empty( $year ) ) {
             $args['year'] = (string) $year;
+        }
+    }
+
+    if ( ! empty( $filters['year_from'] ) ) {
+        $yf = function_exists( 'bw_fpw_normalize_year_bound' ) ? bw_fpw_normalize_year_bound( $filters['year_from'] ) : absint( $filters['year_from'] );
+        if ( ! empty( $yf ) ) {
+            $args['year_from'] = (string) $yf;
+        }
+    }
+
+    if ( ! empty( $filters['year_to'] ) ) {
+        $yt = function_exists( 'bw_fpw_normalize_year_bound' ) ? bw_fpw_normalize_year_bound( $filters['year_to'] ) : absint( $filters['year_to'] );
+        if ( ! empty( $yt ) ) {
+            $args['year_to'] = (string) $yt;
+        }
+    }
+
+    if ( ! empty( $filters['subcategories'] ) && is_array( $filters['subcategories'] ) ) {
+        $sub_ids = array_values( array_filter( array_map( 'absint', $filters['subcategories'] ) ) );
+        if ( ! empty( $sub_ids ) ) {
+            $args['subcategories'] = $sub_ids;
         }
     }
 


### PR DESCRIPTION
Replaces the old browse-group sidebar model with five explicit popup modes: Filter, Trending, New, On Sale, Free. The Filter mode renders a full accordion-based filter panel (subcategories, tags, year range, advanced facets) with chip deselection, live result count, reset, and "Show results" navigation that shares the same URL contract as the search results page.

Feed modes (trending/new/sale/free) render a flat product grid reusing the existing label-based data sources. Suggest behavior is unchanged.

- popup-config.php: 5-mode group+scope definitions (filter/trending/new/sale/free)
- url-state.php: add year_from/year_to and subcategories[] to URL builder
- ajax-search-surface.php: filter/filter_count/feed AJAX branches
- search-surface-template.php: filter footer DOM + localized strings
- search-surface.js: explicit surfaceState.mode, requestMode() dispatcher, renderFeed(), full renderFilter() with accordion/chips/year/count/nav, filter content event delegation, filterApply/filterReset handlers
- search-surface.css: feed grid, filter panel, chips, year inputs, footer CTA