### PR TITLE
Fix advanced filter groups not rendering in popup filter mode

### DIFF
--- a/includes/modules/search-surface/frontend/search-surface.js
+++ b/includes/modules/search-surface/frontend/search-surface.js
@@ -421,9 +421,13 @@
             chips.push({ type: 'year', label: yFrom + '–' + yTo });
         }
         if (sel.advanced) {
+            var advUi = (filterUi.advanced && typeof filterUi.advanced === 'object') ? filterUi.advanced : {};
             Object.keys(sel.advanced).forEach(function (key) {
-                (sel.advanced[key] || []).forEach(function (slug) {
-                    chips.push({ type: 'advanced', key: key, slug: slug, label: slug });
+                var opts = (advUi[key] && Array.isArray(advUi[key].options)) ? advUi[key].options : [];
+                (sel.advanced[key] || []).forEach(function (val) {
+                    var opt   = opts.filter(function (o) { return String(o.value) === String(val); })[0];
+                    var label = opt ? (opt.name || String(val)) : String(val);
+                    chips.push({ type: 'advanced', key: key, slug: val, label: label });
                 });
             });
         }
@@ -536,7 +540,7 @@
         var tags     = Array.isArray(filterUi.tags)  ? filterUi.tags  : [];
         var year     = (filterUi.year && filterUi.year.supported) ? filterUi.year : null;
         var advanced = (filterUi.advanced && typeof filterUi.advanced === 'object') ? filterUi.advanced : {};
-        var advKeys  = Object.keys(advanced).filter(function (k) { return Array.isArray(advanced[k]) && advanced[k].length; });
+        var advKeys  = Object.keys(advanced).filter(function (k) { return advanced[k] && advanced[k].supported && Array.isArray(advanced[k].options) && advanced[k].options.length; });
 
         var initialCount = filterUi.result_count !== undefined ? filterUi.result_count : (payload && payload.result_count !== undefined ? payload.result_count : 0);
         updateFilterCount(surfaceState, initialCount);
@@ -563,7 +567,7 @@
         }
         advKeys.forEach(function (key) {
             var advLabel = key.charAt(0).toUpperCase() + key.slice(1);
-            html += renderFilterGroupHtml('advanced_' + key, advLabel, advanced[key], (surfaceState.filterSel.advanced || {})[key] || [], 'slug');
+            html += renderFilterGroupHtml('advanced_' + key, advLabel, advanced[key].options, (surfaceState.filterSel.advanced || {})[key] || [], 'value');
         });
 
         html += '</div>';


### PR DESCRIPTION
Three JS bugs caused all advanced groups (Artist, Author, Publisher, Source, Technique) to be silently dropped in renderFilter():

- advKeys used Array.isArray(advanced[k]) but the engine sends {supported, options} objects; fix checks advanced[k].supported and Array.isArray(advanced[k].options) instead
- renderFilterGroupHtml was passed advanced[key] (the wrapper) instead of advanced[key].options (the actual items array)
- idField was 'slug' but PHP option items use 'value' as the identifier

Also fixes chip label resolution for selected advanced filters: previously used the raw value token as the label; now looks up the matching item in advanced[key].options by value to display item.name.