### PR TITLE
Enforce single-open accordion in popup filter panel

### DIFF
--- a/includes/modules/search-surface/frontend/search-surface.js
+++ b/includes/modules/search-surface/frontend/search-surface.js
@@ -829,6 +829,18 @@
                 if (group) {
                     var panel = group.querySelector('.bw-search-surface__filter-group-panel');
                     var isOpen = group.classList.contains('is-open');
+                    if (!isOpen) {
+                        Array.prototype.forEach.call(
+                            surfaceState.content.querySelectorAll('.bw-search-surface__filter-group.is-open'),
+                            function (other) {
+                                if (other !== group) {
+                                    other.classList.remove('is-open');
+                                    var otherPanel = other.querySelector('.bw-search-surface__filter-group-panel');
+                                    if (otherPanel) { otherPanel.hidden = true; }
+                                }
+                            }
+                        );
+                    }
                     group.classList.toggle('is-open', !isOpen);
                     if (panel) { panel.hidden = isOpen; }
                 }


### PR DESCRIPTION
Mirrors the discovery-group accordion behavior from the responsive product-grid filter: when a filter group is opened, all other open groups are closed first. Closing a group remains independent.