### PR TITLE
Port responsive drawer active-chip style to popup filter chips

### DIFF
--- a/includes/modules/search-surface/frontend/search-surface.css
+++ b/includes/modules/search-surface/frontend/search-surface.css
@@ -1205,12 +1205,14 @@ body.bw-search-overlay-active {
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    padding: 4px 6px 4px 10px;
-    border-radius: 20px;
-    background: rgba(255, 255, 255, 0.12);
-    border: 1px solid rgba(255, 255, 255, 0.15);
-    font-size: 0.77rem;
-    color: var(--bw-search-surface-text);
+    min-height: 25px;
+    padding: 0 3px 0 10px;
+    border-radius: 999px;
+    background: #141313;
+    border: 1px solid transparent;
+    font-size: 11px;
+    font-weight: 600;
+    color: inherit;
     line-height: 1;
 }
 
@@ -1222,21 +1224,22 @@ body.bw-search-overlay-active {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 18px;
-    height: 18px;
+    width: 14px;
+    height: 14px;
     padding: 0;
     border: none;
-    background: none;
+    background: transparent;
     cursor: pointer;
-    color: var(--bw-search-surface-text-muted);
+    color: inherit;
     border-radius: 50%;
     flex-shrink: 0;
-    transition: background 0.15s, color 0.15s;
+    opacity: 0.72;
+    transition: opacity 0.18s ease;
 }
 
 .bw-search-surface__filter-chip-remove:hover {
-    background: rgba(255, 255, 255, 0.1);
-    color: var(--bw-search-surface-text);
+    background: transparent;
+    opacity: 1;
 }
 
 .bw-search-surface__filter-chip-remove svg {


### PR DESCRIPTION
Copies exact visual values from .bw-fpw-active-chips--drawer .bw-fpw-active-chip.bw-fpw-quick-filter into the popup chip classes:

Chip: min-height 25px, padding 0 3px 0 10px, border-radius 999px, background #141313, transparent border, font-size 11px, font-weight 600, color inherit.

Remove button: 14×14px, opacity 0.72 default → 1 on hover, background/border stay transparent.