### PR TITLE
Search popup: chip bar full-bleed floating strip at top of filter panel

### DIFF
--- a/includes/modules/search-surface/frontend/search-surface.css
+++ b/includes/modules/search-surface/frontend/search-surface.css
@@ -411,7 +411,7 @@ body.bw-search-overlay-active .bw-search-surface[data-bw-search-surface] .bw-sea
     display: flex;
     flex-direction: column;
     padding: 20px 24px 24px;
-    overflow: hidden;
+    overflow: visible;
     background: rgba(255, 255, 255, 0.012);
 }
 
@@ -978,15 +978,13 @@ body.bw-search-overlay-active .bw-search-surface[data-bw-search-surface] .bw-sea
 
 /* Chips */
 .bw-search-surface__filter-chips {
-    position: sticky;
-    top: 0;
     z-index: 6;
     display: flex;
     flex-wrap: wrap;
     gap: 4px;
-    /* bleed past __main (24px) and __content padding-right (6px) */
-    margin: 0 -30px 8px -24px;
-    padding: 8px 30px 10px 24px;
+    /* bleed to the edges of __main's box (absorbing its 24px padding) */
+    margin: -20px -24px 0 -24px;
+    padding: 10px 24px 10px;
     background: #171717d9;
     -webkit-backdrop-filter: blur(24px);
     backdrop-filter: blur(24px);

--- a/includes/modules/search-surface/frontend/search-surface.js
+++ b/includes/modules/search-surface/frontend/search-surface.js
@@ -585,11 +585,12 @@
     }
 
     function updateFilterChips(surfaceState) {
-        var panel = surfaceState && surfaceState.content ? surfaceState.content.querySelector('.bw-search-surface__filter-panel') : null;
-        var chips = surfaceState && surfaceState.content ? surfaceState.content.querySelector('.bw-search-surface__filter-chips') : null;
-        var html = renderFilterChipsHtml(surfaceState);
+        var main  = surfaceState && surfaceState.content ? surfaceState.content.parentNode : null;
+        var chips = main ? main.querySelector(':scope > .bw-search-surface__filter-chips') : null;
+        var html  = renderFilterChipsHtml(surfaceState);
 
         if (!html) {
+            if (chips) { chips.parentNode.removeChild(chips); }
             return;
         }
 
@@ -598,12 +599,9 @@
             return;
         }
 
-        if (panel && panel.parentNode === surfaceState.content) {
-            panel.insertAdjacentHTML('beforebegin', html);
-            return;
+        if (surfaceState.content) {
+            surfaceState.content.insertAdjacentHTML('beforebegin', html);
         }
-
-        surfaceState.content.insertAdjacentHTML('afterbegin', html);
     }
 
     function renderFilterGroupHtml(groupType, label, items, selectedList, idField) {
@@ -1061,6 +1059,33 @@
                 return;
             }
         });
+
+        if (surfaceState.content && surfaceState.content.parentNode) {
+            surfaceState.content.parentNode.addEventListener('click', function (event) {
+                if (surfaceState.mode !== 'filter') { return; }
+                if (surfaceState.content.contains(event.target)) { return; }
+                var chipRemove = event.target.closest('[data-bw-chip-type]');
+                if (!chipRemove) { return; }
+                var chipType = chipRemove.getAttribute('data-bw-chip-type');
+                var chipId   = chipRemove.getAttribute('data-bw-chip-id');
+                var chipKey  = chipRemove.getAttribute('data-bw-chip-key');
+                var chipSlug = chipRemove.getAttribute('data-bw-chip-slug');
+                var cSel = surfaceState.filterSel;
+                if (chipType === 'subcategory' && chipId) {
+                    cSel.subcategories = cSel.subcategories.filter(function (v) { return String(v) !== chipId; });
+                } else if (chipType === 'tag' && chipId) {
+                    cSel.tags = cSel.tags.filter(function (v) { return String(v) !== chipId; });
+                } else if (chipType === 'year') {
+                    cSel.year = { from: null, to: null };
+                } else if (chipType === 'advanced' && chipKey && chipSlug) {
+                    if (cSel.advanced[chipKey]) {
+                        cSel.advanced[chipKey] = cSel.advanced[chipKey].filter(function (s) { return s !== chipSlug; });
+                    }
+                }
+                renderFilter(surfaceState, surfaceState.filterData);
+                scheduleFilterCount(surfaceState);
+            });
+        }
 
         surfaceState.content.addEventListener('input', function (event) {
             if (surfaceState.mode !== 'filter') { return; }


### PR DESCRIPTION
Move chips outside scroll container (sibling of __content, child of __main) so negative margins can bleed to the edges of __main. Add parent-level click handler so chip-remove buttons still work outside surfaceState.content. Also removes chips from DOM when no filters are selected.