### PR TITLE
Search popup: fix chip bar layout via has-chips class on __main

### DIFF
--- a/includes/modules/search-surface/frontend/search-surface.css
+++ b/includes/modules/search-surface/frontend/search-surface.css
@@ -415,6 +415,10 @@ body.bw-search-overlay-active .bw-search-surface[data-bw-search-surface] .bw-sea
     background: rgba(255, 255, 255, 0.012);
 }
 
+.bw-search-surface__main.has-chips {
+    padding-top: 0;
+}
+
 .bw-search-surface__content-header {
     flex: 0 0 auto;
     padding-bottom: 12px;
@@ -982,8 +986,7 @@ body.bw-search-overlay-active .bw-search-surface[data-bw-search-surface] .bw-sea
     display: flex;
     flex-wrap: wrap;
     gap: 4px;
-    /* bleed to the edges of __main's box (absorbing its 24px padding) */
-    margin: -20px -24px 0 -24px;
+    margin: 0 -24px 0 -24px;
     padding: 10px 24px 10px;
     background: #171717d9;
     -webkit-backdrop-filter: blur(24px);

--- a/includes/modules/search-surface/frontend/search-surface.js
+++ b/includes/modules/search-surface/frontend/search-surface.js
@@ -591,17 +591,16 @@
 
         if (!html) {
             if (chips) { chips.parentNode.removeChild(chips); }
+            if (main) { main.classList.remove('has-chips'); }
             return;
         }
 
         if (chips) {
             chips.outerHTML = html;
-            return;
-        }
-
-        if (surfaceState.content) {
+        } else if (surfaceState.content) {
             surfaceState.content.insertAdjacentHTML('beforebegin', html);
         }
+        if (main) { main.classList.add('has-chips'); }
     }
 
     function renderFilterGroupHtml(groupType, label, items, selectedList, idField) {


### PR DESCRIPTION
Replace margin-top:-20px hack (clipped by __body overflow:hidden) with a .has-chips class toggled on __main that drops padding-top to 0, so chips sit flush at the top with clean full-width margin bleed.