### PR TITLE
Fix: payment gateways render empty at checkout

### DIFF
--- a/woocommerce/templates/checkout/form-checkout.php
+++ b/woocommerce/templates/checkout/form-checkout.php
@@ -139,10 +139,21 @@ if (function_exists('bw_mew_render_checkout_header')) {
 
                 <div class="bw-checkout-payment">
                     <?php
+                    // Core WooCommerce passes $available_gateways via woocommerce_checkout_payment(),
+                    // which bw_mew_prepare_checkout_layout() unhooks so the payment section renders
+                    // only in this left column. Replicate that data setup here.
+                    if (WC()->cart && WC()->cart->needs_payment()) {
+                        $available_gateways = WC()->payment_gateways()->get_available_payment_gateways();
+                        WC()->payment_gateways()->set_current_gateway($available_gateways);
+                    } else {
+                        $available_gateways = array();
+                    }
+
                     wc_get_template(
                         'checkout/payment.php',
                         array(
                             'checkout' => $checkout,
+                            'available_gateways' => $available_gateways,
                             'order_button_text' => $order_button_text,
                         )
                     );


### PR DESCRIPTION
## Summary

The checkout page rendered **no payment methods** — customers saw "Sorry, it seems that there are no available payment methods" instead of the gateway list, making checkout unusable.

### Root cause

- `bw_mew_prepare_checkout_layout()` (`woocommerce/woocommerce-init.php:982`) unhooks WooCommerce core's `woocommerce_checkout_payment` from `woocommerce_checkout_order_review`, so the payment section renders only once, in the custom left column.
- That core callback was also responsible for fetching `$available_gateways` and passing it to the `checkout/payment.php` template.
- The plugin's `form-checkout.php` re-renders `payment.php` directly but only passed `checkout` and `order_button_text` — **not `$available_gateways`**.
- In `payment.php:29`, `if (!empty($available_gateways))` on an undefined variable is always `false`, so the template fell through to the "no payment methods" notice.

`checkout/payment.php` is rendered from this single call site only (no AJAX path), so this is the complete fix.

### Change

`form-checkout.php` now replicates the data setup from core's `woocommerce_checkout_payment()` before rendering the template — fetching available gateways, setting the current gateway, and passing `$available_gateways` to `payment.php`.

## Test plan

- [ ] Load the checkout page with at least one active payment gateway — gateway radio options render
- [ ] Load checkout with a cart that needs payment vs. a $0 / no-payment cart — no PHP warnings either way
- [ ] Select a gateway and confirm the chosen method persists across an AJAX checkout update
- [ ] Confirm Google Pay / Apple Pay button wrappers (`payment.php:464,470`) appear when those gateways are active

> Note: verified via root-cause tracing and `php -l` (passes). `composer run lint:changed` could not be run — `composer`/`vendor/` are not installed in this environment. The live checkout UI was not exercised.